### PR TITLE
fix for nested lists

### DIFF
--- a/lib/Pod/Simple/XHTML.pm
+++ b/lib/Pod/Simple/XHTML.pm
@@ -516,8 +516,8 @@ sub start_L {
 
 sub end_L   { $_[0]{'scratch'} .= '</a>' }
 
-sub start_S { $_[0]{'scratch'} .= '<nobr>' }
-sub end_S   { $_[0]{'scratch'} .= '</nobr>' }
+sub start_S { $_[0]{'scratch'} .= '<span style="white-space: nowrap;">' }
+sub end_S   { $_[0]{'scratch'} .= '</span>' }
 
 sub emit {
   my($self) = @_;

--- a/t/xhtml01.t
+++ b/t/xhtml01.t
@@ -521,7 +521,7 @@ $parser->parse_string_document(<<'EOPOD');
 A plain paragraph with S<non breaking text>.
 EOPOD
 is($results, <<"EOHTML", "Non breaking text in a paragraph");
-<p>A plain paragraph with <nobr>non breaking text</nobr>.</p>
+<p>A plain paragraph with <span style="white-space: nowrap;">non breaking text</span>.</p>
 
 EOHTML
 


### PR DESCRIPTION
Hello,

Thank you for this maintaining this wonderful module!  I found an issue where nested =overs produce invalid xhtml. Given the pod in https://gist.github.com/802332, the </li> between "Second of First" and "Second" will not be produced.  To fix this, I've replaced the in_li flag with a stack to keep track of the parent tags.  I've also included two new tests for numbered and bulleted lists.

Cheers,
Fitz Elliott
