### PR TITLE
Implemented backlinks feature into Pod::Simple::Xhtml

### DIFF
--- a/lib/Pod/Simple/XHTML.pm
+++ b/lib/Pod/Simple/XHTML.pm
@@ -249,7 +249,7 @@ sub new {
   $new->{'to_index'} = [];
   $new->{'output'} = [];
   $new->{'saved'} = [];
-  $new->{'ids'} = {};
+  $new->{'ids'} = { '_podtop_' => 1 }; # used in <body>
   $new->{'in_li'} = [];
 
   $new->{'__region_targets'}  = [];
@@ -408,7 +408,7 @@ sub _end_head {
     my $id = $_[0]->idify($_[0]{scratch});
     my $text = $_[0]{scratch};
     $_[0]{'scratch'} = $_[0]->backlink && ($h - $add == 0) # backlinks enabled && =head1
-	                  ? qq{<a href="#top"><h$h id="$id">$text</h$h></a>}
+	                  ? qq{<a href="#_podtop_"><h$h id="$id">$text</h$h></a>}
                           : qq{<h$h id="$id">$text</h$h>};
     $_[0]->emit;
     push @{ $_[0]{'to_index'} }, [$h, $id, $text];
@@ -477,7 +477,7 @@ $doctype
 <title>$title</title>
 $metatags
 </head>
-<body id="top">
+<body id="_podtop_">
 HTML
     $self->emit;
   }

--- a/t/xhtml10.t
+++ b/t/xhtml10.t
@@ -44,7 +44,7 @@ is $results, <<'EOF', 'Should have the index';
 <title></title>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
 </head>
-<body id="top">
+<body id="_podtop_">
 
 
 <ul id="index">
@@ -409,14 +409,14 @@ is $results, <<'EOF', 'Should have the index and a backlink';
 <title></title>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
 </head>
-<body id="top">
+<body id="_podtop_">
 
 
 <ul id="index">
   <li><a href="#Foo">Foo</a></li>
 </ul>
 
-<a href="#top"><h1 id="Foo">Foo</h1></a>
+<a href="#_podtop_"><h1 id="Foo">Foo</h1></a>
 
 </body>
 </html>
@@ -435,7 +435,7 @@ is $results, <<'EOF', 'Should have the index and backlinks';
 <title></title>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
 </head>
-<body id="top">
+<body id="_podtop_">
 
 
 <ul id="index">
@@ -447,12 +447,11 @@ is $results, <<'EOF', 'Should have the index and backlinks';
   <li><a href="#Baz">Baz</a></li>
 </ul>
 
-
-<a href="#top"><h1 id="Foo">Foo</h1></a>
+<a href="#_podtop_"><h1 id="Foo">Foo</h1></a>
 
 <h2 id="Bar">Bar</h2>
 
-<a href="#top"><h1 id="Baz">Baz</h1></a>
+<a href="#_podtop_"><h1 id="Baz">Baz</h1></a>
 
 </body>
 </html>
@@ -472,12 +471,12 @@ is $results, <<'EOF', 'Should have backlinks but no index';
 <title></title>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
 </head>
-<body id="top">
+<body id="_podtop_">
 
 
-<a href="#top"><h1 id="Foo">Foo</h1></a>
+<a href="#_podtop_"><h1 id="Foo">Foo</h1></a>
 
-<a href="#top"><h1 id="Bar">Bar</h1></a>
+<a href="#_podtop_"><h1 id="Bar">Bar</h1></a>
 
 </body>
 </html>
@@ -497,7 +496,7 @@ is $results, <<'EOF', 'Should have index and backlinks around h2 elements';
 <title></title>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
 </head>
-<body id="top">
+<body id="_podtop_">
 
 
 <ul id="index">
@@ -509,9 +508,9 @@ is $results, <<'EOF', 'Should have index and backlinks around h2 elements';
   </li>
 </ul>
 
-<a href="#top"><h2 id="Foo">Foo</h2></a>
+<a href="#_podtop_"><h2 id="Foo">Foo</h2></a>
 
-<a href="#top"><h2 id="Bar">Bar</h2></a>
+<a href="#_podtop_"><h2 id="Bar">Bar</h2></a>
 
 </body>
 </html>


### PR DESCRIPTION
Inspired by Pod::Html, Pod::Simple::Xhtml now has a flag that, if enabled, will turn all =head1 directives into a link pointing to the top of the page, specifically, pointing to the opening body tag.

Also, I fixed a few typos throughout Pod::Simple

Updated this comment to reflect fix from backlinks pointing to the index to backlinks pointing to the opening body tag.
