### PR TITLE
HTML body id attribute only exists if backlink flag is enabled.

### DIFF
--- a/lib/Pod/Simple/XHTML.pm
+++ b/lib/Pod/Simple/XHTML.pm
@@ -458,7 +458,7 @@ sub start_Document {
     $self->{'scratch'} .= $self->html_header;
     $self->emit unless $self->html_header eq "";
   } else {
-    my ($doctype, $title, $metatags);
+    my ($doctype, $title, $metatags, $bodyid);
     $doctype = $self->html_doctype || '';
     $title = $self->force_title || $self->title || $self->default_title || '';
     $metatags = $self->html_header_tags || '';
@@ -470,6 +470,7 @@ sub start_Document {
       $metatags .= "\n<script type='text/javascript' src='" .
                     $self->html_javascript . "'></script>";
     }
+    $bodyid = $self->backlink ? ' id="_podtop_"' : '';
     $self->{'scratch'} .= <<"HTML";
 $doctype
 <html>
@@ -477,7 +478,7 @@ $doctype
 <title>$title</title>
 $metatags
 </head>
-<body id="_podtop_">
+<body$bodyid>
 HTML
     $self->emit;
   }

--- a/t/xhtml10.t
+++ b/t/xhtml10.t
@@ -44,7 +44,7 @@ is $results, <<'EOF', 'Should have the index';
 <title></title>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
 </head>
-<body id="_podtop_">
+<body>
 
 
 <ul id="index">


### PR DESCRIPTION
To keep backwards compatibility, the opening body tag's id attribute only appears if the backlink flag is enabled.
