### PR TITLE
Provide accesor to allow =item directives to be anchored

### DIFF
--- a/lib/Pod/Simple/BlackBox.pm
+++ b/lib/Pod/Simple/BlackBox.pm
@@ -633,7 +633,7 @@ sub _ponder_paragraph_buffer {
           DEBUG and print " Item is of type ", $para->[0], " under $over_type\n";
           
           if($item_type eq 'text') {
-	    # Nothing special needs doing for 'text'
+            # Nothing special needs doing for 'text'
           } elsif($item_type eq 'number' or $item_type eq 'bullet') {
             die "Unknown item type $item_type"
              unless $item_type eq 'number' or $item_type eq 'bullet';


### PR DESCRIPTION
If $parser->anchor_items is enabled, definition =item directives will be id-ified and anchored, allowing them to be linked to.

Note that the =item directives will not be indexed, just anchored.
