### PR TITLE
Add support for \r as a line separator

### DIFF
--- a/lib/Pod/Simple.pm
+++ b/lib/Pod/Simple.pm
@@ -356,7 +356,8 @@ sub parse_string_document {
     next unless defined $line_group and length $line_group;
     pos($line_group) = 0;
     while($line_group =~
-      m/([^\n\r]*)((?:\r?\n)?)/g
+      m/([^\n\r]*)(\r?\n?)/g # supports \r, \n ,\r\n
+      #m/([^\n\r]*)((?:\r?\n)?)/g
     ) {
       #print(">> $1\n"),
       $self->parse_lines($1)
@@ -406,16 +407,29 @@ sub parse_file {
   # By here, $source is a FH.
 
   $self->{'source_fh'} = $source;
-  
+
   my($i, @lines);
   until( $self->{'source_dead'} ) {
     splice @lines;
+
     for($i = MANY_LINES; $i--;) {  # read those many lines at a time
       local $/ = $NL;
       push @lines, scalar(<$source>);  # readline
       last unless defined $lines[-1];
        # but pass thru the undef, which will set source_dead to true
     }
+
+    my $at_eof = !$lines[-1]; # keep track of the undef
+
+    # be eol agnostic
+    s/\r\n?/\n/g for @lines;
+ 
+    # make sure there are only one line elements for parse_lines
+    @lines = split(/(?<=\n)/, join('', @lines));
+
+    # put the undef back b/c the previous split(join()) removes it
+    push @lines, undef if $at_eof;
+
     $self->parse_lines(@lines);
   }
   delete($self->{'source_fh'}); # so it can be GC'd

--- a/t/eol.t
+++ b/t/eol.t
@@ -1,0 +1,107 @@
+#!/usr/bin/perl
+
+# t/eol.t - check handling of \r, \n, and \r\n as line separators
+
+BEGIN {
+    chdir 't' if -d 't';
+}
+
+use warnings;
+use strict;
+use lib '../lib';
+use Test::More tests => 7;
+
+use_ok('Pod::Simple::XHTML') or exit;
+
+open(POD, ">$$.pod") or die "$$.pod: $!";
+print POD <<__EOF__;
+=pod
+
+=head1 NAME
+
+crlf
+
+=head1 DESCRIPTION
+
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+
+    crlf crlf crlf crlf
+    crlf crlf crlf crlf
+    crlf crlf crlf crlf
+
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+
+=cut
+__EOF__
+close(POD);
+
+# --- CR ---
+
+my $p1 = Pod::Simple::XHTML->new ();
+isa_ok ($p1, 'Pod::Simple::XHTML');
+
+open(POD, "<$$.pod") or die "$$.pod: $!";
+open(IN,  ">$$.in")  or die "$$.in: $!";
+while (<POD>) {
+  s/[\r\n]+/\r/g;
+  print IN $_;
+}
+close(POD);
+close(IN);
+
+$p1->output_string(\my $o1);
+$p1->parse_file("$$.in");
+
+# --- LF ---
+
+my $p2 = Pod::Simple::XHTML->new ();
+isa_ok ($p2, 'Pod::Simple::XHTML');
+
+open(POD, "<$$.pod") or die "$$.pod: $!";
+open(IN,  ">$$.in")  or die "$$.in: $!";
+while (<POD>) {
+  s/[\r\n]+/\n/g;
+  print IN $_;
+}
+close(POD);
+close(IN);
+
+$p2->output_string(\my $o2);
+$p2->parse_file("$$.in");
+
+# --- CRLF ---
+
+my $p3 = Pod::Simple::XHTML->new ();
+isa_ok ($p3, 'Pod::Simple::XHTML');
+
+open(POD, "<$$.pod") or die "$$.pod: $!";
+open(IN,  ">$$.in")  or die "$$.in: $!";
+while (<POD>) {
+  s/[\r\n]+/\r\n/g;
+  print IN $_;
+}
+close(POD);
+close(IN);
+
+$p3->output_string(\my $o3);
+$p3->parse_file("$$.in");
+
+# --- now test ---
+
+my $cksum1 = unpack("%32C*", $o1);
+my $cksum2 = unpack("%32C*", $o2);
+my $cksum3 = unpack("%32C*", $o3);
+
+ok($cksum1 == $cksum2, "CR vs LF");
+ok($cksum1 == $cksum3, "CR vs CRLF");
+ok($cksum2 == $cksum3, "LF vs CRLF");
+
+END {
+  1 while unlink("$$.pod", "$$.in");
+}

--- a/t/eol2.t
+++ b/t/eol2.t
@@ -1,0 +1,104 @@
+#!/usr/bin/perl
+
+# t/eol2.t - check handling of \r, \n, and \r\n as line separators (again)
+
+BEGIN {
+    chdir 't' if -d 't';
+}
+
+use warnings;
+use strict;
+use lib '../lib';
+use Test::More tests => 7;
+
+use_ok('Pod::Simple::XHTML') or exit;
+
+open(POD, ">$$.pod") or die "$$.pod: $!";
+print POD <<__EOF__;
+=pod
+
+=head1 NAME
+
+crlf
+
+=head1 DESCRIPTION
+
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+
+    crlf crlf crlf crlf
+    crlf crlf crlf crlf
+    crlf crlf crlf crlf
+
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf crlf
+
+=cut
+__EOF__
+close(POD);
+
+# --- CR ---
+
+my $p1 = Pod::Simple::XHTML->new ();
+isa_ok ($p1, 'Pod::Simple::XHTML');
+
+open(POD, "<$$.pod") or die "$$.pod: $!";
+my $i1 = '';
+while (<POD>) {
+  s/[\r\n]+/\r/g;
+  $i1 .= $_;
+}
+close(POD);
+
+$p1->output_string(\my $o1);
+$p1->parse_string_document($i1);
+
+# --- LF ---
+
+my $p2 = Pod::Simple::XHTML->new ();
+isa_ok ($p2, 'Pod::Simple::XHTML');
+
+open(POD, "<$$.pod") or die "$$.pod: $!";
+my $i2 = '';
+while (<POD>) {
+  s/[\r\n]+/\n/g;
+  $i2 .= $_;
+}
+close(POD);
+
+$p2->output_string(\my $o2);
+$p2->parse_string_document($i2);
+
+# --- CRLF ---
+
+my $p3 = Pod::Simple::XHTML->new ();
+isa_ok ($p3, 'Pod::Simple::XHTML');
+
+open(POD, "<$$.pod") or die "$$.pod: $!";
+my $i3 = '';
+while (<POD>) {
+  s/[\r\n]+/\r\n/g;
+  $i3 .= $_;
+}
+close(POD);
+
+$p3->output_string(\my $o3);
+$p3->parse_string_document($i3);
+
+# --- now test ---
+
+my $cksum1 = unpack("%32C*", $o1);
+my $cksum2 = unpack("%32C*", $o2);
+my $cksum3 = unpack("%32C*", $o3);
+
+ok($cksum1 == $cksum2, "CR vs LF");
+ok($cksum1 == $cksum3, "CR vs CRLF");
+ok($cksum2 == $cksum3, "LF vs CRLF");
+
+END {
+  1 while unlink("$$.pod", "$$.in");
+}


### PR DESCRIPTION
Pod::Simple fails to correctly parse pod documents when '\r' is used as a line separator (as opposed to '\n' and '\r\n'). This commit fixes that, and adds two test cases to demonstrate it. One test case tests the parse_file() method, the other tests parse_string_document().

Note that this commit makes output.t emit a few warnings, which is going to be worked on.
