### PR TITLE
Update test for recurse flag to avoid test failures when run in parallel

### DIFF
--- a/t/search12.t
+++ b/t/search12.t
@@ -75,10 +75,11 @@ ok grep( m/squaa\.pm/, keys %$where2name ), 1;
 
 ###### Now with recurse(0)
 
-print "# Testing the surveying of a current directory without recursing...\n";
+print "# Testing the surveying of a subdirectory with recursing off...\n";
 
 $x->recurse(0);
-($name2where, $where2name) = $x->survey($cwd);
+($name2where, $where2name) = $x->survey(
+                             File::Spec->catdir($cwd, 't', 'testlib2'));
 
 $p = pretty( $where2name, $name2where )."\n";
 $p =~ s/, +/,\n/g;
@@ -87,17 +88,17 @@ print $p;
 
 {
 my $names = join "|", sort values %$where2name;
-ok $names, "";
+ok $names, "Suzzle";
 }
 
 {
 my $names = join "|", sort keys %$name2where;
-ok $names, "";
+ok $names, "Suzzle";
 }
 
-ok( ($name2where->{'squaa'} || 'huh???'), 'huh???');
+ok( ($name2where->{'Vliff'} || 'huh???'), 'huh???');
 
-ok grep( m/squaa\.pm/, keys %$where2name ), 0;
+ok grep( m/Vliff\.pm/, keys %$where2name ), 0;
 
 ok 1;
 


### PR DESCRIPTION
t/search12.t used to survey pod-simple/ for any POD documents, expecting none

t/puller.t creates and deletes a temporary POD file in pod-simple/

If the two are run in parallel, the former may fail. To fix this, my commit surveys pod-simple/t/testlib2/ instead, a directory in which no POD files are temporarily created.
