### PR TITLE
Add a 'pod_handler' option to Pod::Simple, similar to 'cut_handler'.

### DIFF
--- a/lib/Pod/Simple.pm
+++ b/lib/Pod/Simple.pm
@@ -94,9 +94,11 @@ __PACKAGE__->_accessorize(
 
  'code_handler',      # coderef to call when a code (non-pod) line is seen
  'cut_handler',       # coderef to call when a =cut line is seen
+ 'pod_handler',       # coderef to call when a =pod line is seen
  #Called like:
  # $code_handler->($line, $self->{'line_count'}, $self) if $code_handler;
  #  $cut_handler->($line, $self->{'line_count'}, $self) if $cut_handler;
+ #  $pod_handler->($line, $self->{'line_count'}, $self) if $pod_handler;
 
 );
 

--- a/lib/Pod/Simple/BlackBox.pm
+++ b/lib/Pod/Simple/BlackBox.pm
@@ -1092,7 +1092,18 @@ sub _ponder_pod {
     "=pod directives shouldn't be over one line long!  Ignoring all "
      . (@$para - 2) . " lines of content"
   ) if @$para > 3;
-  # Content is always ignored.
+
+  # Content ignored unless 'pod_handler' is set
+  if (my $pod_handler = $self->{'pod_handler'}) {
+      my ($line_num, $line) = map $_, $para->[1]{'start_line'}, $para->[2];
+      $line = $line eq '' ? "=pod" : "=pod $line"; # imitate cut_handler output
+      $pod_handler->($line, $line_num, $self);
+  }
+
+  # The surrounding methods set content_seen, so let us remain consistent.
+  # I do not know why it was not here before -- should it not be here?
+  # $self->{'content_seen'} ||= 1;
+
   return;
 }
 

--- a/lib/Pod/Simple/Subclassing.pod
+++ b/lib/Pod/Simple/Subclassing.pod
@@ -783,6 +783,13 @@ This is just like the code_handler attribute, except that it's for
 unlikely to be interesting, but this is included for completeness.
 
 
+=item C<< $parser->pod_handler(  I<CODE_REF>  ) >>
+
+This is just like the code_handler attribute, except that it's for
+"=pod" lines, not code lines. The same caveats apply. "=pod" lines are
+unlikely to be interesting, but this is included for completeness.
+
+
 =item C<< $parser->whine( I<linenumber>, I<complaint string> ) >>
 
 This notes a problem in the Pod, which will be reported to in the "Pod

--- a/t/cbacks.t
+++ b/t/cbacks.t
@@ -43,9 +43,16 @@ while(@from) {
     sub {
      $_[0]->code_handler(sub { $more .= $_[1] . ":" . $_[0] . "\n"       } );
      $_[0]->cut_handler( sub { $more .= "~" . $_[1] . ":" .  $_[0]. "\n" } );
+     $_[0]->pod_handler( sub { $more .= "~" . $_[1] . ":" .  $_[0]. "\n" } );
     } => join "\n",
     "",
     "\t# This is handy...",
+    "=pod text",
+    "",
+    "=cut more text",
+    "",
+    "=pod",
+    "",
     "=head1 I  LIKE   PIE",
     "",
     "=cut",
@@ -64,10 +71,14 @@ while(@from) {
   ok scalar($got = $more), scalar($exp = join "\n" =>
    "1:",
    "2:\t# This is handy...",
-   "~5:=cut",
-   "6:use Test::Harness;",
-   "7:runtests(sort glob 't/*.t');",
-   "8:",
+   "~3:=pod text",
+   "~5:=cut more text",
+   "6:",
+   "~7:=pod",
+   "~11:=cut",
+   "12:use Test::Harness;",
+   "13:runtests(sort glob 't/*.t');",
+   "14:",
    "",
   );
   unless($got eq $exp) {


### PR DESCRIPTION
In an effort to be complete, this commit introduces an option that allows the user to handle '=pod' directive lines.

Also, I added a comment asking why content_seen seen is not set to true if a =pod directive is found. I forgot to remove it before pushing the commit, and I am leaving it because I do not know the answer.

This commit consists of the added code, documentation, and test cases.
