### PR TITLE
Add a todo regarding valid E<>'s content

### DIFF
--- a/lib/Pod/Simple.pm
+++ b/lib/Pod/Simple.pm
@@ -1349,6 +1349,10 @@ sub _treat_Es {
 
       DEBUG > 1 and print "Ogling E<$content>\n";
 
+      # XXX E<>'s contents *should* be a valid char in the scope of the current
+      # =encoding directive. Defaults to iso-8859-1, I believe. Fix this in the
+      # future sometime.
+
       $charnum  = Pod::Escapes::e2charnum($content);
       DEBUG > 1 and print " Considering E<$content> with char ",
         defined($charnum) ? $charnum : "undef", ".\n";


### PR DESCRIPTION
It turns out that Pod::Simple's E<> resolutions match what rjbs outlined in the meeting so I did not need to update anything in Pod::Simple. theory, you asked me to document the optimal behavior, so here it is.
