### PR TITLE
Fix bug that incorrectly parsed =begin/=ends inside =overs

### DIFF
--- a/lib/Pod/Simple/BlackBox.pm
+++ b/lib/Pod/Simple/BlackBox.pm
@@ -592,7 +592,8 @@ sub _ponder_paragraph_buffer {
       if($para_type eq '=item') {
 
         my $over;
-        unless(@$curr_open and ($over = $curr_open->[-1])->[0] eq '=over') {
+        unless(@$curr_open and
+               $over = (grep { $_->[0] eq '=over' } @$curr_open)[-1]) {
           $self->whine(
             $para->[1]{'start_line'},
             "'=item' outside of any '=over'"
@@ -1199,7 +1200,8 @@ sub _ponder_back {
 sub _ponder_item {
   my ($self,$para,$curr_open,$paras) = @_;
   my $over;
-  unless(@$curr_open and ($over = $curr_open->[-1])->[0] eq '=over') {
+  unless(@$curr_open and
+         $over = (grep { $_->[0] eq '=over' } @$curr_open)[-1]) {
     $self->whine(
       $para->[1]{'start_line'},
       "'=item' outside of any '=over'"


### PR DESCRIPTION
Instead of checking that the _most recent_ opened block is an =over upon
encountering an =item, ::BlackBox now checks if _any_ currently opened
block is an =over. This allows =begin and =for blocks to nest inside of
=open blocks, as per perlpodspec.
