### PR TITLE
Blacklist what doesn't make a whiteline instead of whitelisting what does

### DIFF
--- a/lib/Pod/Simple/BlackBox.pm
+++ b/lib/Pod/Simple/BlackBox.pm
@@ -193,7 +193,7 @@ sub parse_lines {             # Usage: $parser->parse_lines(@lines)
       #  of order relative to pods, but in order relative to code.
       
     } elsif($line =~ m/^(\s*)$/s) {  # it's a blank line
-      if (defined $1 and $1 =~ /[\t ]/) { # it's a white line
+      if (defined $1 and $1 =~ /[^\S\r\n]/) { # it's a white line
         $wl_handler->(map $_, $line, $self->{'line_count'}, $self)
           if $wl_handler;
       }


### PR DESCRIPTION
Instead of saying that a blank line matching `/[\t ]/` is a whiteline, check a wider array of characters by blacklisting what shouldn't through the following the regex: `/[^\S\r\n]/`.
