### PR TITLE
Whine on first non-ASCII byte-sequence and use it to guess Latin1 vs UTF8

### DIFF
--- a/t/corpus/encwarn01.txt
+++ b/t/corpus/encwarn01.txt
@@ -1,0 +1,11 @@
+
+=head1 NAME
+
+Encoding Warning 1 - implicitly Latin-1
+
+=head2 DESCRIPTION
+
+This line should warn that the word café contains a non-ASCII character.
+
+But château should not generate a warning - once is enough.
+

--- a/t/corpus/encwarn01.xml
+++ b/t/corpus/encwarn01.xml
@@ -1,0 +1,38 @@
+<Document start_line="2">
+  <head1 start_line="2">
+    NAME
+  </head1>
+  <Para start_line="4">
+    Encoding Warning 1 - implicitly Latin-1
+  </Para>
+  <head2 start_line="6">
+    DESCRIPTION
+  </head2>
+  <Para start_line="8">
+    This line should warn that the word caf&#233; contains a
+    non-ASCII character.
+  </Para>
+  <Para start_line="10">
+    But ch&#226;teau should not generate a warning - once is
+    enough.
+  </Para>
+  <head1 errata="1" start_line="-321">
+    POD ERRORS
+  </head1>
+  <Para errata="1" start_line="-321">
+    Hey! 
+    <B>
+      The above document had some coding errors, which are explained
+      below:
+    </B>
+  </Para>
+  <over-text errata="1" indent="4" start_line="-321">
+    <item-text start_line="-321">
+      Around line 8:
+    </item-text>
+    <Para start_line="-321">
+      Non-ASCII character seen before =encoding in &#39;caf&#233;&#39;.
+      Assuming ISO8859-1
+    </Para>
+  </over-text>
+</Document>

--- a/t/corpus/encwarn02.txt
+++ b/t/corpus/encwarn02.txt
@@ -1,0 +1,11 @@
+
+=head1 NAME
+
+Encoding Warning 1 - implicitly UTF-8
+
+=head2 DESCRIPTION
+
+This line should warn that the price €9.99 contains a non-ASCII character.
+
+But château should not generate a warning - once is enough.
+

--- a/t/corpus/encwarn02.xml
+++ b/t/corpus/encwarn02.xml
@@ -1,0 +1,38 @@
+<Document start_line="2">
+  <head1 start_line="2">
+    NAME
+  </head1>
+  <Para start_line="4">
+    Encoding Warning 1 - implicitly UTF-8
+  </Para>
+  <head2 start_line="6">
+    DESCRIPTION
+  </head2>
+  <Para start_line="8">
+    This line should warn that the price &#8364;9.99 contains
+    a non-ASCII character.
+  </Para>
+  <Para start_line="10">
+    But ch&#226;teau should not generate a warning - once is
+    enough.
+  </Para>
+  <head1 errata="1" start_line="-321">
+    POD ERRORS
+  </head1>
+  <Para errata="1" start_line="-321">
+    Hey! 
+    <B>
+      The above document had some coding errors, which are explained
+      below:
+    </B>
+  </Para>
+  <over-text errata="1" indent="4" start_line="-321">
+    <item-text start_line="-321">
+      Around line 8:
+    </item-text>
+    <Para start_line="-321">
+      Non-ASCII character seen before =encoding in &#39;&#8364;9.99&#39;.
+      Assuming UTF-8
+    </Para>
+  </over-text>
+</Document>

--- a/t/corpus/lat1frim.xml
+++ b/t/corpus/lat1frim.xml
@@ -67,4 +67,23 @@
   <Para start_line="33">
     [end]
   </Para>
+  <head1 errata="1" start_line="-321">
+    POD ERRORS
+  </head1>
+  <Para errata="1" start_line="-321">
+    Hey! 
+    <B>
+      The above document had some coding errors, which are explained
+      below:
+    </B>
+  </Para>
+  <over-text errata="1" indent="4" start_line="-321">
+    <item-text start_line="-321">
+      Around line 11:
+    </item-text>
+    <Para start_line="-321">
+      Non-ASCII character seen before =encoding in &#39;s&#233;parant&#39;.
+      Assuming ISO8859-1
+    </Para>
+  </over-text>
 </Document>


### PR DESCRIPTION
This commit makes two\* changes:

If a non-ASCII byte is encountered when no =encoding has been seen, a warning will be generated (first time only).

When the above happens, a heuristic (from perlpodspec) is applied to select UTF-8 encoding if the non-ASCII bytes form a valid UTF-8 byte sequence, or Latin-1 otherwise.
- I would not normally change two pieces of functionality with one commit however the second change conveniently sets a flag which enables the warning to only occur on the first non-ASCII byte.
