### PR TITLE
Don't turn on codes_in_verbatim by default for the XHTML formatter

### DIFF
--- a/lib/Pod/Simple/XHTML.pm
+++ b/lib/Pod/Simple/XHTML.pm
@@ -251,7 +251,6 @@ sub new {
   $new->man_url_prefix('http://man.he.net/man');
   $new->html_charset('ISO-8859-1');
   $new->nix_X_codes(1);
-  $new->codes_in_verbatim(1);
   $new->{'scratch'} = '';
   $new->{'to_index'} = [];
   $new->{'output'} = [];

--- a/t/xhtml01.t
+++ b/t/xhtml01.t
@@ -657,6 +657,7 @@ SKIP: for my $use_html_entities (0, 1) {
   }
   local $Pod::Simple::XHTML::HAS_HTML_ENTITIES = $use_html_entities;
   initialize($parser, $results);
+  $parser->codes_in_verbatim(1);
   $parser->parse_string_document(<<'EOPOD');
 =pod
 


### PR DESCRIPTION
I suggest codes_in_verbatim ought to be off by default.  The XTHML formatter ought to be compatible with the other formatters by default.
