### PR TITLE
suppress spurious warnings

### DIFF
--- a/lib/Pod/Simple/BlackBox.pm
+++ b/lib/Pod/Simple/BlackBox.pm
@@ -179,6 +179,7 @@ sub parse_lines {             # Usage: $parser->parse_lines(@lines)
 
     # HERE WE CATCH =encoding EARLY!
     if( $line =~ m/^=encoding\s+\S+\s*$/s ) {
+      next if $self->parse_characters;   # Ignore this line
       $line = $self->_handle_encoding_line( $line );
     }
 

--- a/t/enc-chars.t
+++ b/t/enc-chars.t
@@ -52,7 +52,4 @@ else {
   ok(0);
 }
 
-
-
-warn $output;
 exit;


### PR DESCRIPTION
This removes the source of the warnings introduced by the earlier patch. - Sorry
