### PR TITLE
Fix a seekrut vs htmlversion typo 

### DIFF
--- a/lib/Pod/Simple/HTMLBatch.pm
+++ b/lib/Pod/Simple/HTMLBatch.pm
@@ -1093,7 +1093,7 @@ Example:
 
   % mkdir ../seekrut
   % chmod og-rx ../seekrut
-  % perl -MPod::Simple::HTMLBatch -e Pod::Simple::HTMLBatch::go . ../htmlversion
+  % perl -MPod::Simple::HTMLBatch -e Pod::Simple::HTMLBatch::go . ../seekrut
       (to convert the pod under the current dir into HTML
        files under the directory ./seekrut)
 


### PR DESCRIPTION
The HTMLBatch doc has an example for a seekrut directory and most of the directory names were updated, but one was missed.
