### PR TITLE
Fix src attribute on script tag to use matching quotes

### DIFF
--- a/lib/Pod/Simple/XHTML.pm
+++ b/lib/Pod/Simple/XHTML.pm
@@ -535,7 +535,7 @@ sub start_Document {
     }
     if ($self->html_javascript) {
       $metatags .= qq{\n<script type="text/javascript" src="} .
-                    $self->html_javascript . "'></script>";
+                    $self->html_javascript . '"></script>';
     }
     $bodyid = $self->backlink ? ' id="_podtop_"' : '';
     $self->{'scratch'} .= <<"HTML";


### PR DESCRIPTION
Quotes were being generated mis-matched: <script type="text/javascript" src="$url'></script>.  This doesn't work for me in current Chrome on Windows and causes the entire page to be blank.
