### PR TITLE
Fix list of chars in 'encode chars' example

### DIFF
--- a/lib/Pod/Simple/XHTML.pm
+++ b/lib/Pod/Simple/XHTML.pm
@@ -38,7 +38,7 @@ you can prevent high-bit characters from being encoded as HTML entities and
 declare the output character set as UTF-8 before parsing, like so:
 
   $psx->html_charset('UTF-8');
-  $psx->html_encode_chars('&<>">');
+  $psx->html_encode_chars(q{&<>'"});
 
 =cut
 


### PR DESCRIPTION
`>` was doubled and `'` wasn't part of the string.