### PR TITLE
Fix spurious test failures due to mismatched directory separators.

### DIFF
--- a/t/search50.t
+++ b/t/search50.t
@@ -72,11 +72,10 @@ while (my ($testmod, $testpath) = each %{ $name2where }) {
   }
   my @x = ($x->find($testmod)||'(nil)', $testpath);
   # print "# Comparing \"$x[0]\" to \"$x[1]\"\n";
-  for(@x) { s{[/\\]}{/}g; }
   # print "#        => \"$x[0]\" to \"$x[1]\"\n";
   is(
       File::Spec->rel2abs($x[0]),
-      $x[1],
+      File::Spec->rel2abs($x[1]),
       " find('$testmod') should match survey's name2where{$testmod}"
   );
 }


### PR DESCRIPTION
On Windows with my perl 5.22.0 build using Visual Studio 2013, I get

<pre>t\search50.t (Wstat: 65024 Tests: 2958 Failed: 2950)
  Failed tests:  8-2957
  Non-zero exit status: 254
Files=1, Tests=2958, 71 wallclock secs ( 1.17 usr +  0.08 sys =  1.25 CPU)
Result: FAIL</pre>

All of those failures are of the form:

<pre>#   Failed test ' find('Template::Test') should match survey's name2where{Template::Test}'
#   at t\search50.t line 78.
#          got: 'C:\...\site\lib\Template\Test.pm'
#     expected: 'C:/.../site/lib/Template/Test.pm'
# Looks like you failed 2950 tests of 2958.</pre>

That is, they are failing due to discrepancies in directory separators in the returned versus expected paths.

This is caused by first canonicalizing both paths to use Unix-style directory separators everywhere, and, then, later only applying `File::Spec->rel2abs` to the returned path in the actual test.

Getting rid of the `s{[/\\]}{/}g` fixes all the reported errors, but, for additional robustness, I recommend applying `File::Spec->rel2abs` to both arguments in the test.