### PR TITLE
Add errata_seen()

### DIFF
--- a/lib/Pod/Simple.pm
+++ b/lib/Pod/Simple.pm
@@ -130,6 +130,10 @@ sub any_errata_seen {  # good for using as an exit() value...
   return shift->{'errors_seen'} || 0;
 }
 
+sub errata_seen {
+  return shift->{'all_errata'} || {};
+}
+
 # Returns the encoding only if it was recognized as being handled and set
 sub detected_encoding {
   return shift->{'detected_encoding'};
@@ -541,6 +545,7 @@ sub whine {
     DEBUG > 9 and print "Discarding complaint (at line $_[0]) $_[1]\n because no_whining is on.\n";
     return;
   }
+  push @{$self->{'all_errata'}{$_[0]}}, $_[1];
   return $self->_complain_warn(@_) if $self->{'complain_stderr'};
   return $self->_complain_errata(@_);
 }
@@ -549,6 +554,7 @@ sub scream {    # like whine, but not suppressible
   #my($self,$line,$complaint) = @_;
   my $self = shift(@_);
   ++$self->{'errors_seen'};
+  push @{$self->{'all_errata'}{$_[0]}}, $_[1];
   return $self->_complain_warn(@_) if $self->{'complain_stderr'};
   return $self->_complain_errata(@_);
 }

--- a/lib/Pod/Simple.pod
+++ b/lib/Pod/Simple.pod
@@ -289,6 +289,16 @@ I<Example:>
 
   die "too many errors\n" if $parser->any_errata_seen();
 
+=item C<< $parser->errata_seen() >>X<errata_seen>
+
+Returns a hash reference of all errata seen, both whines and screams. The hash reference's keys are the line number and the value is an array reference of the errors for that line.
+
+I<Example:>
+
+  if ( $parser->any_errata_seen() ) {
+     $logger->log( $parser->errata_seen() );
+  }
+
 =item C<< $parser->detected_encoding() >>X<detected_encoding>
 
 Return the encoding corresponding to C<< =encoding >>, but only if the

--- a/lib/Pod/Simple/BlackBox.pm
+++ b/lib/Pod/Simple/BlackBox.pm
@@ -2111,7 +2111,7 @@ sub reinit {
   my $self = shift;
   foreach (qw(source_dead source_filename doc_has_started
 start_of_pod_block content_seen last_was_blank paras curr_open
-line_count pod_para_count in_pod ~tried_gen_errata errata errors_seen
+line_count pod_para_count in_pod ~tried_gen_errata all_errata errata errors_seen
 Title)) {
 
     delete $self->{$_};

--- a/t/whine.t
+++ b/t/whine.t
@@ -6,42 +6,26 @@ use Test::More tests => 4;
   package Pod::Simple::ErrorFinder;
   use base 'Pod::Simple::DumpAsXML'; # arbitrary choice -- rjbs, 2013-04-16
 
-  my @errors;
-  sub whine {
-    my ($self, @rest) = @_;
-    push @errors, [ @rest ];
-    $self->SUPER::whine(@rest);
-  }
-
-  sub scream {
-    my ($self, @rest) = @_;
-    push @errors, [ @rest ];
-    $self->SUPER::scream(@rest);
-  }
-
   sub errors_for_input {
     my ($class, $input, $mutor) = @_;
-    @errors = ();
 
     my $parser = $class->new;
     my $output = '';
     $parser->output_string( \$output );
+    $parser->no_errata_section(1);
     $parser->parse_string_document( $input );
 
-    @errors = sort { $a->[0] <=> $b->[0]
-                  || $a->[1] cmp $b->[1] } @errors;
-
-    return @errors;
+    return $parser->errata_seen();
   }
 }
 
 sub errors { Pod::Simple::ErrorFinder->errors_for_input(@_) }
 
 {
-  my @errors = errors("=over 4\n\n=item 1\n\nHey\n\n");
+  my $errors = errors("=over 4\n\n=item 1\n\nHey\n\n");
   is_deeply(
-    \@errors,
-    [ [ 1, "=over without closing =back" ] ],
+    $errors,
+    { 1 => [ "=over without closing =back" ] },
     "no closing =back",
   );
 }
@@ -49,10 +33,10 @@ sub errors { Pod::Simple::ErrorFinder->errors_for_input(@_) }
 {
   for my $l_code ('L< foo>', 'L< bar>') {
     my $input = "=pod\n\nAmbiguous space: $l_code\n";
-    my @errors = errors("$input");
+    my $errors = errors("$input");
     is_deeply(
-      \@errors,
-      [ [ 3, "L<> starts or ends with whitespace" ] ],
+      $errors,
+      { 3 => [ "L<> starts or ends with whitespace" ] },
       "warning for space in $l_code",
     );
   }
@@ -60,10 +44,10 @@ sub errors { Pod::Simple::ErrorFinder->errors_for_input(@_) }
 
 {
   my $input = "=pod\n\nAmbiguous slash: L<I/O Operators|op/io>\n";
-  my @errors = errors("$input");
+  my $errors = errors("$input");
   is_deeply(
-    \@errors,
-    [ [ 3, "alternative text 'I/O Operators' contains non-escaped | or /" ] ],
+    $errors,
+    { 3 => [ "alternative text 'I/O Operators' contains non-escaped | or /" ] },
     "warning for / in text part of L<>",
   );
 }


### PR DESCRIPTION
`errata_seen()` returns a hash reference of errata with the line
number as the key and the errors on that line as the value.

To support situations where neither STDERR nor the "POD ERRORS" section are used but pod errors still need to be processed ( logged, etc ), I decided to create the `all_errata` key on the parser instead of using the `errata` key. Currently the `errata` key stands for errata in the "POD ERRORS" section and not all errata seen. If `errata_seen()` used the `errata` key and the `no_errata_section` attribute was set to true, it would return no errors. So I created an all inclusive key.

To test the new method, I converted `t/whine.t` to use it and as a result, `t/whine.t` is slightly cleaner.

Solves #71

Brought to you by the [CPAN PR challenge](cpan-prc.org).