### PR TITLE
Paths returned from survey are expected to be absolute

### DIFF
--- a/t/search50.t
+++ b/t/search50.t
@@ -75,7 +75,7 @@ while (my ($testmod, $testpath) = each %{ $name2where }) {
   # print "#        => \"$x[0]\" to \"$x[1]\"\n";
   is(
       File::Spec->rel2abs($x[0]),
-      File::Spec->rel2abs($x[1]),
+      $x[1],
       " find('$testmod') should match survey's name2where{$testmod}"
   );
 }


### PR DESCRIPTION
Therefore, remove unnecessary and possibly harmful `rel2abs`.

My PR #70 applied rel2abs to paths returned from `survey`. In subsequent discussion, [@kenahoo pointed out](https://github.com/perl-pod/pod-simple/pull/70#issuecomment-136401355) that this might cause violations of the API contract ("survey returns absolute paths") to be missed.

Further, since `survey` takes care to call `canonpath` on paths it considers, I am assuming it is also part of the contract that it always returns canonicalized paths, and violations of that should
also be detected.

Therefore, this PR removes the `rel2abs` applied to the path returned from `survey` (`$x[1]`) in this particular test.