### PR TITLE
Adds Encode 2.78 as a runtime/recommends (GH#77)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -48,6 +48,14 @@ WriteMakefile(
         mailto => 'bug-pod-simple@rt.cpan.org',
       },
     },
+    prereqs => {
+      runtime => {
+        recommends => {
+          'Encode' => 2.78, # Pod::Simple's new default code page (1252) is
+                            # pre-compiled in 2.78, which improves performance.
+        },
+      },
+    },
   },
 
 );


### PR DESCRIPTION
- In Encode 2.78 the code page 1252 (the new default for Pod::Simple) is
  pre-compiled (see dankogai/p5-encode#42), which means a speed improvement.