### PR TITLE
Avoid 'Negative repeat count does nothing' warnings after Pod::Simple::Checker finds a pod error

### DIFF
--- a/lib/Pod/Simple/Checker.pm
+++ b/lib/Pod/Simple/Checker.pm
@@ -88,8 +88,10 @@ sub end_item_text   { $_[0]->emit_par(-2) }
 sub emit_par {
   return unless $_[0]{'Errata_seen'};
   my($self, $tweak_indent) = splice(@_,0,2);
-  my $indent = ' ' x ( 2 * $self->{'Indent'} + ($tweak_indent||0) );
+  my $length = 2 * $self->{'Indent'} + ($tweak_indent||0);
+  my $indent = ' ' x ($length > 0 ? $length : 0);
    # Yes, 'STRING' x NEGATIVE gives '', same as 'STRING' x 0
+   # 'Negative repeat count does nothing' since 5.22
 
   $self->{'Thispara'} =~ s/$Pod::Simple::shy//g;
   my $out = Text::Wrap::wrap($indent, $indent, $self->{'Thispara'} .= "\n");


### PR DESCRIPTION
There is a comment in lib/Pod/Simple/Checker.pm that says "Yes, 'STRING' x NEGATIVE gives '', same as 'STRING' x 0", but unfortunately this leads to 'Negative repeat count does nothing' warning since Perl 5.22. This PR is to silence the warning.
