### PR TITLE
search.cpan.org was shut down some months ago.

### DIFF
--- a/lib/Pod/Simple/HTML.pm
+++ b/lib/Pod/Simple/HTML.pm
@@ -29,7 +29,7 @@ $LamePad = '' unless defined $LamePad;
 
 $Linearization_Limit = 120 unless defined $Linearization_Limit;
  # headings/items longer than that won't get an <a name="...">
-$Perldoc_URL_Prefix  = 'http://search.cpan.org/perldoc?'
+$Perldoc_URL_Prefix  = 'https://metacpan.org/pod/'
  unless defined $Perldoc_URL_Prefix;
 $Perldoc_URL_Postfix = ''
  unless defined $Perldoc_URL_Postfix;

--- a/lib/Pod/Simple/XHTML.pm
+++ b/lib/Pod/Simple/XHTML.pm
@@ -92,7 +92,7 @@ the call to C<parse_file>:
 
 In turning L<Foo::Bar> into http://whatever/Foo%3a%3aBar, what
 to put before the "Foo%3a%3aBar". The default value is
-"http://search.cpan.org/perldoc?".
+"https://metacpan.org/pod/".
 
 =head2 perldoc_url_postfix
 
@@ -247,7 +247,7 @@ sub new {
   my $self = shift;
   my $new = $self->SUPER::new(@_);
   $new->{'output_fh'} ||= *STDOUT{IO};
-  $new->perldoc_url_prefix('http://search.cpan.org/perldoc?');
+  $new->perldoc_url_prefix('https://metacpan.org/pod/');
   $new->man_url_prefix('http://man.he.net/man');
   $new->html_charset('ISO-8859-1');
   $new->nix_X_codes(1);
@@ -685,8 +685,8 @@ sub emit {
 Resolves a POD link target (typically a module or POD file name) and section
 name to a URL. The resulting link will be returned for the above examples as:
 
-  http://search.cpan.org/perldoc?Net::Ping#INSTALL
-  http://search.cpan.org/perldoc?perlpodspec
+  https://metacpan.org/pod/Net::Ping#INSTALL
+  https://metacpan.org/pod/perlpodspec
   #SYNOPSIS
 
 Note that when there is only a section argument the URL will simply be a link

--- a/t/fcodes_s.t
+++ b/t/fcodes_s.t
@@ -219,7 +219,7 @@ ok(
 
 # Test HTML output of links.
 use Pod::Simple::HTML;
-my $PERLDOC = "http://search.cpan.org/perldoc";
+my $PERLDOC = "https://metacpan.org/pod";
 my $MANURL = "http://man.he.net/man";
 sub x ($) {
     Pod::Simple::HTML->_out(
@@ -230,12 +230,12 @@ sub x ($) {
 
 ok(
     x(qq{L<Net::Ping>\n}),
-    qq{\n<p><a href="$PERLDOC?Net%3A%3APing" class="podlinkpod"\n>Net::Ping</a></p>\n}
+    qq{\n<p><a href="$PERLDOC/Net%3A%3APing" class="podlinkpod"\n>Net::Ping</a></p>\n}
 );
 
 ok(
     x(qq{Be sure to read the L<Net::Ping> docs\n}),
-    qq{\n<p>Be sure to read the <a href="$PERLDOC?Net%3A%3APing" class="podlinkpod"\n>Net::Ping</a> docs</p>\n}
+    qq{\n<p>Be sure to read the <a href="$PERLDOC/Net%3A%3APing" class="podlinkpod"\n>Net::Ping</a> docs</p>\n}
 );
 
 ok(
@@ -250,7 +250,7 @@ ok(
 
 ok(
     x(qq{L<Net::Ping/Ping-pong>\n}),
-    qq{\n<p><a href="$PERLDOC?Net%3A%3APing#Ping-pong" class="podlinkpod"\n>&#34;Ping-pong&#34; in Net::Ping</a></p>\n}
+    qq{\n<p><a href="$PERLDOC/Net%3A%3APing#Ping-pong" class="podlinkpod"\n>&#34;Ping-pong&#34; in Net::Ping</a></p>\n}
 );
 
 ok(
@@ -270,7 +270,7 @@ ok(
 
 ok(
     x(qq{L<Net::Ping/Ping-E<112>ong>\n}),
-    qq{\n<p><a href="$PERLDOC?Net%3A%3APing#Ping-pong" class="podlinkpod"\n>&#34;Ping-pong&#34; in Net::Ping</a></p>\n}
+    qq{\n<p><a href="$PERLDOC/Net%3A%3APing#Ping-pong" class="podlinkpod"\n>&#34;Ping-pong&#34; in Net::Ping</a></p>\n}
 );
 
 ok(
@@ -315,17 +315,17 @@ ok(
 
 ok(
     x(qq{L<Perl Error Messages|perldiag>\n}),
-    qq{\n<p><a href="$PERLDOC?perldiag" class="podlinkpod"\n>Perl Error Messages</a></p>\n}
+    qq{\n<p><a href="$PERLDOC/perldiag" class="podlinkpod"\n>Perl Error Messages</a></p>\n}
 );
 
 ok(
     x(qq{L<Perl\nError\nMessages|perldiag>\n}),
-    qq{\n<p><a href="$PERLDOC?perldiag" class="podlinkpod"\n>Perl Error Messages</a></p>\n}
+    qq{\n<p><a href="$PERLDOC/perldiag" class="podlinkpod"\n>Perl Error Messages</a></p>\n}
 );
 
 ok(
     x(qq{L<Perl\nError\t  Messages|perldiag>\n}),
-    qq{\n<p><a href="$PERLDOC?perldiag" class="podlinkpod"\n>Perl Error Messages</a></p>\n}
+    qq{\n<p><a href="$PERLDOC/perldiag" class="podlinkpod"\n>Perl Error Messages</a></p>\n}
 );
 
 ok(
@@ -352,12 +352,12 @@ sub o ($) {
 
 ok(
     o(qq{L<Net::Ping>}),
-    qq{<p><a href="$PERLDOC?Net::Ping">Net::Ping</a></p>\n\n}
+    qq{<p><a href="$PERLDOC/Net::Ping">Net::Ping</a></p>\n\n}
 );
 
 ok(
     o(qq{Be sure to read the L<Net::Ping> docs}),
-    qq{<p>Be sure to read the <a href="$PERLDOC?Net::Ping">Net::Ping</a> docs</p>\n\n}
+    qq{<p>Be sure to read the <a href="$PERLDOC/Net::Ping">Net::Ping</a> docs</p>\n\n}
 );
 
 ok(
@@ -372,7 +372,7 @@ ok(
 
 ok(
     o(qq{L<Net::Ping/Ping-pong>}),
-    qq{<p><a href="$PERLDOC?Net::Ping#Ping-pong">&quot;Ping-pong&quot; in Net::Ping</a></p>\n\n}
+    qq{<p><a href="$PERLDOC/Net::Ping#Ping-pong">&quot;Ping-pong&quot; in Net::Ping</a></p>\n\n}
 );
 
 ok(
@@ -392,7 +392,7 @@ ok(
 
 ok(
     o(qq{L<Net::Ping/Ping-E<112>ong>}),
-    qq{<p><a href="$PERLDOC?Net::Ping#Ping-pong">&quot;Ping-pong&quot; in Net::Ping</a></p>\n\n}
+    qq{<p><a href="$PERLDOC/Net::Ping#Ping-pong">&quot;Ping-pong&quot; in Net::Ping</a></p>\n\n}
 );
 
 ok(
@@ -437,17 +437,17 @@ ok(
 
 ok(
     o(qq{L<Perl Error Messages|perldiag>}),
-    qq{<p><a href="$PERLDOC?perldiag">Perl Error Messages</a></p>\n\n}
+    qq{<p><a href="$PERLDOC/perldiag">Perl Error Messages</a></p>\n\n}
 );
 
 ok(
     o(qq{L<Perl\nError\nMessages|perldiag>}),
-    qq{<p><a href="$PERLDOC?perldiag">Perl Error Messages</a></p>\n\n}
+    qq{<p><a href="$PERLDOC/perldiag">Perl Error Messages</a></p>\n\n}
 );
 
 ok(
     o(qq{L<Perl\nError\t  Messages|perldiag>}),
-    qq{<p><a href="$PERLDOC?perldiag">Perl Error Messages</a></p>\n\n}
+    qq{<p><a href="$PERLDOC/perldiag">Perl Error Messages</a></p>\n\n}
 );
 
 ok(

--- a/t/xhtml01.t
+++ b/t/xhtml01.t
@@ -18,7 +18,7 @@ isa_ok ($parser, 'Pod::Simple::XHTML');
 
 my $results;
 
-my $PERLDOC = "http://search.cpan.org/perldoc";
+my $PERLDOC = "https://metacpan.org/pod";
 my $MANURL = "http://man.he.net/man";
 
 initialize($parser, $results);
@@ -541,7 +541,7 @@ $parser->parse_string_document(<<'EOPOD');
 A plain paragraph with a L<Newlines>.
 EOPOD
 is($results, <<"EOHTML", "Link entity in a paragraph");
-<p>A plain paragraph with a <a href="$PERLDOC?Newlines">Newlines</a>.</p>
+<p>A plain paragraph with a <a href="$PERLDOC/Newlines">Newlines</a>.</p>
 
 EOHTML
 
@@ -552,7 +552,7 @@ $parser->parse_string_document(<<'EOPOD');
 A plain paragraph with a L<perlport/Newlines>.
 EOPOD
 is($results, <<"EOHTML", "Link entity in a paragraph");
-<p>A plain paragraph with a <a href="$PERLDOC?perlport#Newlines">&quot;Newlines&quot; in perlport</a>.</p>
+<p>A plain paragraph with a <a href="$PERLDOC/perlport#Newlines">&quot;Newlines&quot; in perlport</a>.</p>
 
 EOHTML
 
@@ -742,16 +742,16 @@ like $results, qr{\Q<meta http-equiv="Content-Type" content="text/html; charset=
 
 # Test the link generation methods.
 is $parser->resolve_pod_page_link('Net::Ping', 'INSTALL'),
-    "$PERLDOC?Net::Ping#INSTALL",
+    "$PERLDOC/Net::Ping#INSTALL",
     'POD link with fragment';
 is $parser->resolve_pod_page_link('perlpodspec'),
-    "$PERLDOC?perlpodspec", 'Simple POD link';
+    "$PERLDOC/perlpodspec", 'Simple POD link';
 is $parser->resolve_pod_page_link(undef, 'SYNOPSIS'), '#SYNOPSIS',
     'Simple fragment link';
 is $parser->resolve_pod_page_link(undef, 'this that'), '#this-that',
     'Fragment link with space';
 is $parser->resolve_pod_page_link('perlpod', 'this that'),
-    "$PERLDOC?perlpod#this-that",
+    "$PERLDOC/perlpod#this-that",
     'POD link with fragment with space';
 
 is $parser->resolve_man_page_link('crontab(5)', 'EXAMPLE CRON FILE'),


### PR DESCRIPTION
The main page for module searches is MetaCPAN now, so change the URL
to metacpan.org