### PR TITLE
Eliminate a few documentation TODOs

### DIFF
--- a/lib/Pod/Simple/HTMLBatch.pm
+++ b/lib/Pod/Simple/HTMLBatch.pm
@@ -1110,12 +1110,15 @@ Example:
 
 =item $batchconv = Pod::Simple::HTMLBatch->new;
 
-This TODO
-
+This creates a new batch converter.  The method doesn't take parameters.
+To change the converter's attributes, use the L<"/ACCESSOR METHODS">
+below.
 
 =item $batchconv->batch_convert( I<indirs>, I<outdir> );
 
-this TODO
+This searches the directories given in I<indirs> and writes
+HTML files for each of these to a corresponding directory
+in I<outdir>.  The directory I<outdir> must exist.
 
 =item $batchconv->batch_convert( undef    , ...);
 

--- a/lib/Pod/Simple/Subclassing.pod
+++ b/lib/Pod/Simple/Subclassing.pod
@@ -98,9 +98,14 @@ nodes that represent preformatted text (from verbatim sections).
 TODO intro... mention that events are supplied for implicits, like for
 missing >'s
 
-
 In the following section, we use XML to represent the event structure
-associated with a particular construct.  That is, TODO
+associated with a particular construct.  That is, an opening tag
+represents the element start, the attributes of that opening tag are
+the attributes given to the callback, and the closing tag represents
+the end element.
+
+Three callback methods must be supplied by a class extending
+L<Pod::Simple> to receive the corresponding event:
 
 =over
 
@@ -112,8 +117,9 @@ associated with a particular construct.  That is, TODO
 
 =back
 
-TODO describe
-
+Here's the comprehensive list of values you can expect as
+I<element_name> in your implementation of C<_handle_element_start>
+and C<_handle_element_end>::
 
 =over
 


### PR DESCRIPTION
Here's just a few lines of documentation where the Pod has TODOs and I had to read the sources to find out what's going on.