### PR TITLE
Accommodate 'env PERL_UNICODE=""'

### DIFF
--- a/t/JustPod_corpus.t
+++ b/t/JustPod_corpus.t
@@ -63,7 +63,7 @@ foreach my $file (@test_files) {
   $parser->complain_stderr(0);
 
   my $input;
-  open( IN , '<' , $file ) or die "$file: $!";
+  open( IN , '<:raw' , $file ) or die "$file: $!";
   $input .= $_ while (<IN>);
   close( IN );
 


### PR DESCRIPTION
Shortly after release of perl-5.30.0, a change in Pod-Simple in blead
led to smoke-test failures from previously reliable smokers in
t/JustPod_corpus.t.  Dave Mitchell suggested this change, which
eliminates the test failure when this CPAN distro is tested against a
perl built from blead along these lines:

    env PERL_UNICODE="" \
      ~/testing/blead/bin/perl -I~/testing/blead/lib -Iblib/lib \
      t/JustPod_corpus.t