### PR TITLE
Conditionally add pods directory to those find uses

### DIFF
--- a/lib/Pod/Simple/Search.pm
+++ b/lib/Pod/Simple/Search.pm
@@ -259,7 +259,7 @@ sub _path2modname {
   while(@m
     and defined($x = lc( $m[0] ))
     and(  $x eq 'site_perl'
-       or($x eq 'pod' and @m == 1 and $shortname =~ m{^perl.*\.pod$}s )
+       or($x =~ m/^pods?$/ and @m == 1 and $shortname =~ m{^perl.*\.pod$}s )
        or $x =~ m{\\d+\\.z\\d+([_.]?\\d+)?}  # if looks like a vernum
        or $x eq lc( $Config::Config{'archname'} )
   )) { shift @m }
@@ -611,7 +611,7 @@ sub find {
     }
 
     # Case-insensitively Look for ./pod directories and slip them in.
-    for my $subdir ( _actual_filenames($dir, 'pod') ) {
+    for my $subdir ( _actual_filenames($dir, 'pods'), _actual_filenames($dir, 'pod') ) {
       if (-d $subdir) {
         $verbose and print "Noticing $subdir and looking there...\n";
         unshift @search_dirs, $subdir;

--- a/t/search20.t
+++ b/t/search20.t
@@ -78,16 +78,16 @@ require $ascii_order;
 
 {
 my $names = join "|", sort ascii_order values %$where2name;
-skip $^O eq 'VMS' ? '-- case may or may not be preserved' : 0, 
-     $names, 
-     "Blorm|Suzzle|Zonk::Pronk|hinkhonk::Glunk|hinkhonk::Vliff|perlflif|perlthng|perlzuk|squaa|squaa::Glunk|squaa::Vliff|squaa::Wowo|zikzik";
+skip $^O eq 'VMS' ? '-- case may or may not be preserved' : 0,
+     $names,
+     "Blorm|Suzzle|Zonk::Pronk|hinkhonk::Glunk|hinkhonk::Vliff|perlflif|perlthng|perlzoned|perlzuk|squaa|squaa::Glunk|squaa::Vliff|squaa::Wowo|zikzik";
 }
 
 {
 my $names = join "|", sort ascii_order keys %$name2where;
-skip $^O eq 'VMS' ? '-- case may or may not be preserved' : 0, 
-     $names, 
-     "Blorm|Suzzle|Zonk::Pronk|hinkhonk::Glunk|hinkhonk::Vliff|perlflif|perlthng|perlzuk|squaa|squaa::Glunk|squaa::Vliff|squaa::Wowo|zikzik";
+skip $^O eq 'VMS' ? '-- case may or may not be preserved' : 0,
+     $names,
+     "Blorm|Suzzle|Zonk::Pronk|hinkhonk::Glunk|hinkhonk::Vliff|perlflif|perlthng|perlzoned|perlzuk|squaa|squaa::Glunk|squaa::Vliff|squaa::Wowo|zikzik";
 }
 
 ok( ($name2where->{'squaa'} || 'huh???'), '/squaa\.pm$/');

--- a/t/search22.t
+++ b/t/search22.t
@@ -8,7 +8,7 @@ BEGIN {
 use strict;
 use Pod::Simple::Search;
 use Test;
-BEGIN { plan tests => 13 }
+BEGIN { plan tests => 15 }
 
 print "# ", __FILE__,
  ": Testing the scanning of several docroots...\n";
@@ -80,17 +80,17 @@ require $ascii_order;
 {
 print "# won't show any shadows, since we're just looking at the name2where keys\n";
 my $names = join "|", sort ascii_order keys %$name2where;
-skip $^O eq 'VMS' ? '-- case may or may not be preserved' : 0, 
-     $names, 
-     "Blorm|Suzzle|Zonk::Pronk|hinkhonk::Glunk|hinkhonk::Vliff|perlflif|perlthng|perlzuk|squaa|squaa::Glunk|squaa::Vliff|squaa::Wowo|zikzik";
+skip $^O eq 'VMS' ? '-- case may or may not be preserved' : 0,
+     $names,
+     "Blorm|Suzzle|Zonk::Pronk|hinkhonk::Glunk|hinkhonk::Vliff|perlflif|perlthng|perlzoned|perlzuk|squaa|squaa::Glunk|squaa::Vliff|squaa::Wowo|zikzik";
 }
 
 {
 print "# but here we'll see shadowing:\n";
 my $names = join "|", sort ascii_order values %$where2name;
-skip $^O eq 'VMS' ? '-- case may or may not be preserved' : 0, 
-     $names, 
-     "Blorm|Suzzle|Zonk::Pronk|hinkhonk::Glunk|hinkhonk::Glunk|hinkhonk::Vliff|hinkhonk::Vliff|perlflif|perlthng|perlthng|perlzuk|squaa|squaa::Glunk|squaa::Vliff|squaa::Vliff|squaa::Vliff|squaa::Wowo|zikzik";
+skip $^O eq 'VMS' ? '-- case may or may not be preserved' : 0,
+     $names,
+     "Blorm|Suzzle|Zonk::Pronk|hinkhonk::Glunk|hinkhonk::Glunk|hinkhonk::Vliff|hinkhonk::Vliff|perlflif|perlthng|perlthng|perlzoned|perlzuk|squaa|squaa::Glunk|squaa::Vliff|squaa::Vliff|squaa::Vliff|squaa::Wowo|zikzik";
 
 my %count;
 for(values %$where2name) { ++$count{$_} };
@@ -120,7 +120,9 @@ skip $^O eq 'VMS' ? '-- case may or may not be preserved' : 0,
     ($name2where->{'squaa::Wowo'}  || 'huh???'), 
     '/testlib2/';
 
-
+my $in_pods = $x->find('perlzoned', $here2);
+ok $in_pods, qr{^$here2};
+ok $in_pods, qr{perlzoned.pod$};
 
 print "# OK, bye from ", __FILE__, "\n";
 ok 1;

--- a/t/testlib2/pods/perlzoned.pod
+++ b/t/testlib2/pods/perlzoned.pod
@@ -1,0 +1,5 @@
+=head1 NAME
+
+perlzoned - This is just some test file
+
+=cut


### PR DESCRIPTION
Handle the decisions that [installperl](https://github.com/Perl/perl5/blob/191f8909fa4eca1db16a91ada42dd4a065c04890/installperl#L533-L544) makes. The `perl*.pod` files can reside in a `pods` directory rather than `pod` for certain architectures..
## References

* #108