### PR TITLE
configure requires ExtUtils::MakeMaker 6.64

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,6 +29,9 @@ WriteMakefile(
             if integer File::Find Test::More
             ]
     },
+    CONFIGURE_REQUIRES => {
+        'ExtUtils::MakeMaker' => '6.64',
+    },
 
     INSTALLDIRS => $] >= 5.009003 && $] <= 5.011000 ? 'perl' : 'site',
 


### PR DESCRIPTION
Currently we cannot install Pod::Simple with old perls because it requires ExtUtils::MakeMaker 6.64 in configure phase, but it is not listed in META.json.

```
❯ perl -v

This is perl 5, version 16, subversion 3 (v5.16.3) built for darwin-2level
...


❯ curl -fsSL https://cpanmin.us | perl - Pod::Simple
--> Working on Pod::Simple
Fetching http://www.cpan.org/authors/id/K/KH/KHW/Pod-Simple-3.41.tar.gz ... OK
Configuring Pod-Simple-3.41 ... N/A
! Configure failed for Pod-Simple-3.41. See /Users/skaji/.cpanm/work/1604583331.23818/build.log for details.


❯ tail -13 /Users/skaji/.cpanm/work/1604583331.23818/build.log
--> Working on Pod::Simple
Fetching http://www.cpan.org/authors/id/K/KH/KHW/Pod-Simple-3.41.tar.gz
-> OK
Unpacking Pod-Simple-3.41.tar.gz
Entering Pod-Simple-3.41
Checking configure dependencies from META.json
Checking if you have ExtUtils::MakeMaker 6.58 ... Yes (6.63_02)
Configuring Pod-Simple-3.41
Running Makefile.PL
ExtUtils::MakeMaker version 6.64 required--this is only version 6.6302 at Makefile.PL line 12.
BEGIN failed--compilation aborted at Makefile.PL line 12.
-> N/A
-> FAIL Configure failed for Pod-Simple-3.41. See /Users/skaji/.cpanm/work/1604583331.23818/build.log for details.
```

This PR adds ExtUtils::MakeMaker 6.64 to CONFIGURE_REQUIRES.