### PR TITLE
Let's 'use' Pod::Simple::TiedOutFH instead of 'require'-ing it

### DIFF
--- a/lib/Pod/Simple.pm
+++ b/lib/Pod/Simple.pm
@@ -8,6 +8,7 @@ use integer;
 use Pod::Escapes 1.04 ();
 use Pod::Simple::LinkSection ();
 use Pod::Simple::BlackBox ();
+use Pod::Simple::TiedOutFH;
 #use utf8;
 
 use vars qw(
@@ -202,7 +203,6 @@ sub output_string {
   my $this = shift;
   return $this->{'output_string'} unless @_;  # GET.
   
-  require Pod::Simple::TiedOutFH;
   my $x = (defined($_[0]) and ref($_[0])) ? $_[0] : \( $_[0] );
   $$x = '' unless defined $$x;
   DEBUG > 4 and print STDERR "# Output string set to $x ($$x)\n";


### PR DESCRIPTION
This will facilitate refactoring of libraries in the Perl 5 core
distribution which 'use' Pod::Simple.