### PR TITLE
remove extra entity encode when generating pod links

### DIFF
--- a/lib/Pod/Simple/XHTML.pm
+++ b/lib/Pod/Simple/XHTML.pm
@@ -750,7 +750,7 @@ sub resolve_pod_page_link {
     }
 
     return ($self->perldoc_url_prefix || '')
-        . $self->encode_entities($to) . $section
+        . $to . $section
         . ($self->perldoc_url_postfix || '');
 }
 


### PR DESCRIPTION
resolve_pod_page_link should return the URL, not in entity encoded form.
When it is used, the output already gets encoded. Given that module
names won't generally have anything to encode, the double encode was
overlooked.