### PR TITLE
fix tab expansion when set to a value other than 0 or 8

### DIFF
--- a/lib/Pod/Simple/BlackBox.pm
+++ b/lib/Pod/Simple/BlackBox.pm
@@ -1770,9 +1770,10 @@ sub _ponder_Verbatim {
     # Fix illegal settings for expand_verbatim_tabs()
     # This is because this module doesn't do input error checking, but khw
     # doesn't want to add yet another instance of that.
-    $self->expand_verbatim_tabs(8)
-                            if ! defined $self->expand_verbatim_tabs()
-                            ||   $self->expand_verbatim_tabs() =~ /\D/;
+    my $tab_width = $self->expand_verbatim_tabs;
+    $tab_width = $self->expand_verbatim_tabs(8)
+        if ! defined $tab_width
+        ||   $tab_width =~ /\D/;
 
     my $indent = $self->strip_verbatim_indent;
     if ($indent && ref $indent eq 'CODE') {
@@ -1785,7 +1786,7 @@ sub _ponder_Verbatim {
       foreach my $line ($para->[$i]) { # just for aliasing
         # Strip indentation.
         $line =~ s/^\Q$indent// if $indent;
-        next unless $self->expand_verbatim_tabs;
+        next unless $tab_width;
 
             # This is commented out because of github issue #85, and the
             # current maintainers don't know why it was there in the first
@@ -1794,8 +1795,8 @@ sub _ponder_Verbatim {
         while( $line =~
           # Sort of adapted from Text::Tabs.
           s/^([^\t]*)(\t+)/$1.(" " x ((length($2)
-                                       * $self->expand_verbatim_tabs)
-                                       -(length($1)&7)))/e
+                                       * $tab_width)
+                                       -(length($1) % $tab_width)))/e
         ) {}
 
         # TODO: whinge about (or otherwise treat) unindented or overlong lines

--- a/t/strpvbtm.t
+++ b/t/strpvbtm.t
@@ -1,7 +1,7 @@
 # t/strip_verbatim_indent.t.t - check verbatim indent stripping feature
 use strict;
 use warnings;
-use Test::More tests => 103;
+use Test::More tests => 107;
 
 use_ok('Pod::Simple::XHTML') or exit;
 use_ok('Pod::Simple::XMLOutStream') or exit;
@@ -133,6 +133,12 @@ for my $spec (
         1,
         "<pre><code>  foo bar baz</code></pre>\n\n",
         'tabs are xlate to one space each'
+    ],
+    [
+        "\n=pod\n\n\tfoo\tbaar\tbaz\n",
+        4,
+        "<pre><code>    foo baar    baz</code></pre>\n\n",
+        'tabs are xlate to four spaces each, with correct tabstops for inner tabs'
     ],
 ) {
     my ($pod, $tabs, $xhtml, $desc) = @$spec;


### PR DESCRIPTION
The original code doing tab expansion used >>3 and &7 as optimized
versions of * 8 and % 8. When updating the code to allow arbitrary tab
widths, the >> 3 was updated, but the &7 was mistakenly left in place.