### PR TITLE
t/ - minor parallelism fixes to test files

### DIFF
--- a/t/JustPod_corpus.t
+++ b/t/JustPod_corpus.t
@@ -25,7 +25,10 @@ BEGIN {
 
   sub wanted {
     push @test_files, $File::Find::name
-      if $File::Find::name =~ /\.pod$/;
+      if $File::Find::name =~ /\.pod$/
+      && $File::Find::name !~ /temp/; # ignore any files named temp,
+                                      # a different test file may have
+                                      # created it
   }
   find(\&wanted , $test_dir );
 

--- a/t/puller.t
+++ b/t/puller.t
@@ -207,13 +207,13 @@ is $t[4]->tagname, 'Document';
 }
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-END { unlink "temp.pod" }
+our $temp_pod = "temp_$$.pod";
+END { unlink "$temp_pod" }
 {
 print "# Testing pullparsing from a file\n";
 my $p = Pod::Simple::PullParser->new;
 ok 1;
-open(OUT, ">temp.pod") || die "Can't write-open temp.pod: $!";
+open(OUT, ">$temp_pod") || die "Can't write-open $temp_pod: $!";
 print OUT
  map "$_\n",
   '','Bzorch', '','=pod', '', 'Lala', 'zaza', '', '=cut'
@@ -222,7 +222,7 @@ close(OUT);
 ok 1;
 sleep 1;
 
-$p->set_source("temp.pod");
+$p->set_source("$temp_pod");
 
 my( @t, $t );
 while($t = $p->get_token) {
@@ -251,7 +251,7 @@ is $t[4]->tagname, 'Document';
 print "# Testing pullparsing from a glob\n";
 my $p = Pod::Simple::PullParser->new;
 ok 1;
-open(IN, "<temp.pod") || die "Can't read-open temp.pod: $!";
+open(IN, "<$temp_pod") || die "Can't read-open $temp_pod: $!";
 $p->set_source(*IN);
 
 my( @t, $t );
@@ -282,7 +282,7 @@ close(IN);
 print "# Testing pullparsing from a globref\n";
 my $p = Pod::Simple::PullParser->new;
 ok 1;
-open(IN, "<temp.pod") || die "Can't read-open temp.pod: $!";
+open(IN, "<$temp_pod") || die "Can't read-open $temp_pod: $!";
 $p->set_source(\*IN);
 
 my( @t, $t );
@@ -313,7 +313,7 @@ close(IN);
 print "# Testing pullparsing from a filehandle\n";
 my $p = Pod::Simple::PullParser->new;
 ok 1;
-open(IN, "<temp.pod") || die "Can't read-open temp.pod: $!";
+open(IN, "<$temp_pod") || die "Can't read-open $temp_pod: $!";
 $p->set_source(*IN{IO});
 
 my( @t, $t );


### PR DESCRIPTION
The test file t/puller.t cannot be run at the same time as itself, and t/JustPod_corpus.t may have a race with it as well. This patch changes puller.t to use a process private temp file, and it teaches JustPod_corpus.t to ignore files with "temp" in their name, as that is what puller.t creates.

We have had reports that Pod-Simple tests fail under parallel test mode in perl core. This hopefully fixes the problem, although I personally have been unable to recreate the race condition in core, I have been able to make puller.t fail when run against itself, which is at least an indicator it is not parallel safe. Karl Williamson however has experienced these failures.