### PR TITLE
XHTML: =over without =item should render as a blockquote

### DIFF
--- a/lib/Pod/Simple/XHTML.pm
+++ b/lib/Pod/Simple/XHTML.pm
@@ -458,7 +458,7 @@ sub start_item_text   {
 }
 
 sub start_over_bullet { $_[0]{'scratch'} = '<ul>'; push @{$_[0]{'in_li'}}, 0; $_[0]->emit }
-sub start_over_block  { $_[0]{'scratch'} = '<ul>'; $_[0]->emit }
+sub start_over_block  { $_[0]{'scratch'} = '<blockquote>'; $_[0]->emit }
 sub start_over_number { $_[0]{'scratch'} = '<ol>'; push @{$_[0]{'in_li'}}, 0; $_[0]->emit }
 sub start_over_text   {
     $_[0]{'scratch'} = '<dl>';
@@ -467,7 +467,7 @@ sub start_over_text   {
     $_[0]->emit
 }
 
-sub end_over_block  { $_[0]{'scratch'} .= '</ul>'; $_[0]->emit }
+sub end_over_block  { $_[0]{'scratch'} .= '</blockquote>'; $_[0]->emit }
 
 sub end_over_number   {
     $_[0]{'scratch'} = "</li>\n" if ( pop @{$_[0]{'in_li'}} );

--- a/t/xhtml01.t
+++ b/t/xhtml01.t
@@ -1,7 +1,7 @@
 # t/xhtml01.t - check basic output from Pod::Simple::XHTML
 use strict;
 use warnings;
-use Test::More tests => 64;
+use Test::More tests => 65;
 
 use_ok('Pod::Simple::XHTML') or exit;
 
@@ -456,6 +456,27 @@ is($results, <<'EOHTML', 'multiparagraph nested lists');
 </dl>
 
 EOHTML
+
+
+initialize($parser, $results);
+$parser->parse_string_document(<<'EOPOD');
+=over
+
+Over section without any =item directives.
+
+=back
+
+EOPOD
+
+is($results, <<'EOHTML', 'multiparagraph nested lists');
+<blockquote>
+
+<p>Over section without any =item directives.</p>
+
+</blockquote>
+
+EOHTML
+
 
 initialize($parser, $results);
 $parser->parse_string_document(<<'EOPOD');


### PR DESCRIPTION
If an =over section doesn't include =item directives under it, it is meant to be interpreted as an indented section or block quote. Producing a `<ul>` element with something other than `<li>` inside it is invalid HTML.

Change the XHTML formatter to produce a `<blockquote>` element for this type of =over section, matching the HTML formatter and the Pod spec's recommendation.