### PR TITLE
Add support for U<> to format text as underlined

### DIFF
--- a/lib/Pod/Simple.pm
+++ b/lib/Pod/Simple.pm
@@ -13,7 +13,7 @@ use Pod::Simple::TiedOutFH;
 our @ISA = ('Pod::Simple::BlackBox');
 our $VERSION = '3.44';
 
-our @Known_formatting_codes = qw(I B C L E F S X Z);
+our @Known_formatting_codes = qw(I B C L E F S U X Z);
 our %Known_formatting_codes = map(($_=>1), @Known_formatting_codes);
 our @Known_directives       = qw(head1 head2 head3 head4 head5 head6 item over back);
 our %Known_directives       = map(($_=>'Plain'), @Known_directives);
@@ -754,7 +754,7 @@ sub _remap_sequences {
         ref($map->{$_}) ? join(",", @{$map->{$_}}) : $map->{$_}
       ),
       sort keys %$map ),
-    ("B~C~E~F~I~L~S~X~Z" eq join '~', sort keys %$map)
+    ("B~C~E~F~I~L~S~U~X~Z" eq join '~', sort keys %$map)
      ? "  (all normal)\n" : "\n"
   ;
 

--- a/lib/Pod/Simple/HTML.pm
+++ b/lib/Pod/Simple/HTML.pm
@@ -125,7 +125,7 @@ our %Tagmap = (
 
   changes(qw(
     Para=p
-    B=b I=i
+    B=b I=i U=u
     over-bullet=ul
     over-number=ol
     over-text=dl
@@ -164,6 +164,7 @@ our %Tagmap = (
 
   'B'      =>  "<b>",                  '/B'     =>  "</b>",
   'I'      =>  "<i>",                  '/I'     =>  "</i>",
+  'U'      =>  "<u>",                  '/U'     =>  "</u>",
   'F'      =>  "<em$Computerese>",     '/F'     =>  "</em>",
   'C'      =>  "<code$Computerese>",   '/C'     =>  "</code>",
   'L'  =>  "<a href='YOU_SHOULD_NEVER_SEE_THIS'>", # ideally never used!

--- a/lib/Pod/Simple/JustPod.pm
+++ b/lib/Pod/Simple/JustPod.pm
@@ -214,6 +214,7 @@ sub start_E { _start_fcode('E', @_); }
 sub start_F { _start_fcode('F', @_); }
 sub start_I { _start_fcode('I', @_); }
 sub start_S { _start_fcode('S', @_); }
+sub start_U { _start_fcode('U', @_); }
 sub start_X { _start_fcode('X', @_); }
 sub start_Z { _start_fcode('Z', @_); }
 
@@ -242,6 +243,7 @@ sub _end_fcode {
 *end_F   = *_end_fcode;
 *end_I   = *_end_fcode;
 *end_S   = *_end_fcode;
+*end_U   = *_end_fcode;
 *end_X   = *_end_fcode;
 *end_Z   = *_end_fcode;
 

--- a/lib/Pod/Simple/RTF.pm
+++ b/lib/Pod/Simple/RTF.pm
@@ -86,6 +86,7 @@ our %Tagmap = (
  _openclose(
   'B=cs18\b',
   'I=cs16\i',
+  'U=cs30\ul',
   'C=cs19\f1\lang1024\noproof',
   'F=cs17\i\lang1024\noproof',
 
@@ -413,6 +414,7 @@ sub stylesheet {
 {\*\cs17 \additive \i\lang1024\noproof \sbasedon10 pod-F;}
 {\*\cs18 \additive \b \sbasedon10 pod-B;}
 {\*\cs19 \additive \f1\lang1024\noproof\sbasedon10 pod-C;}
+{\*\cs30 \additive \ul \sbasedon10 pod-U;}
 {\s20\ql \li0\ri0\sa180\widctlpar\f1\fs%s\lang1024\noproof\sbasedon0 \snext0 pod-codeblock;}
 {\*\cs21 \additive \lang1024\noproof \sbasedon10 pod-computerese;}
 {\*\cs22 \additive \i\lang1024\noproof\sbasedon10 pod-L-pod;}

--- a/lib/Pod/Simple/Subclassing.pod
+++ b/lib/Pod/Simple/Subclassing.pod
@@ -172,7 +172,7 @@ produces this event structure:
       in the document.
     </Para>
 
-=item events with an element_name of B, C, F, or I.
+=item events with an element_name of B, C, F, I, or U.
 
 Parsing a BE<lt>...E<gt> formatting code (or of course any of its
 semantically identical syntactic variants
@@ -190,7 +190,7 @@ Parsing C, F, or I codes produce the same structure, with only a
 different element name.
 
 If your parser object has been set to accept other formatting codes,
-then they will be presented like these B/C/F/I codes -- i.e., without
+then they will be presented like these B/C/F/I/U codes -- i.e., without
 any attributes.
 
 =item events with an element_name of S
@@ -212,7 +212,7 @@ means non-breaking space.
 =item events with an element_name of X
 
 Normally, parsing an XE<lt>...E<gt> sequence produces this event
-structure, just as if it were a B/C/F/I code:
+structure, just as if it were a B/C/F/I/U code:
 
       <X>
         ...stuff...
@@ -775,7 +775,7 @@ At time of writing, I don't think you'll need to use this.
 =item C<< $parser->accept_codes( I<Codename>, I<Codename>...  ) >>
 
 This tells the parser that you accept additional formatting codes,
-beyond just the standard ones (I B C L F S X, plus the two weird ones
+beyond just the standard ones (I B C L F S U X, plus the two weird ones
 you don't actually see in the parse tree, Z and E). For example, to also
 accept codes "N", "R", and "W":
 

--- a/lib/Pod/Simple/XHTML.pm
+++ b/lib/Pod/Simple/XHTML.pm
@@ -699,6 +699,9 @@ sub end_F   { $_[0]{'scratch'} .= '</i>' }
 sub start_I { $_[0]{'scratch'} .= '<i>' }
 sub end_I   { $_[0]{'scratch'} .= '</i>' }
 
+sub start_U { $_[0]{'scratch'} .= '<u>' }
+sub end_U   { $_[0]{'scratch'} .= '</u>' }
+
 sub start_L {
   my ($self, $flags) = @_;
     my ($type, $to, $section) = @{$flags}{'type', 'to', 'section'};

--- a/t/html02.t
+++ b/t/html02.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 6;
+use Test::More tests => 7;
 
 #use Pod::Simple::Debug (10);
 use Pod::Simple::HTML;
@@ -20,6 +20,7 @@ my @pairs = (
 [ 'C<code>'         => qq{\n<p><code>code</code></p>\n} ],
 [ 'F</tmp/foo>'     => qq{\n<p><em>/tmp/foo</em></p>\n} ],
 [ 'F</tmp/foo>'     => qq{\n<p><em>/tmp/foo</em></p>\n} ],
+[ 'U<underlined>'   => qq{\n<p><u>underlined</u></p>\n} ],
 );
 
 

--- a/t/rtf_utf8.t
+++ b/t/rtf_utf8.t
@@ -85,6 +85,7 @@ __DATA__
 {\*\cs17 \additive \i\lang1024\noproof \sbasedon10 pod-F;}
 {\*\cs18 \additive \b \sbasedon10 pod-B;}
 {\*\cs19 \additive \f1\lang1024\noproof\sbasedon10 pod-C;}
+{\*\cs30 \additive \ul \sbasedon10 pod-U;}
 {\s20\ql \li0\ri0\sa180\widctlpar\f1\fs18\lang1024\noproof\sbasedon0 \snext0 pod-codeblock;}
 {\*\cs21 \additive \lang1024\noproof \sbasedon10 pod-computerese;}
 {\*\cs22 \additive \i\lang1024\noproof\sbasedon10 pod-L-pod;}

--- a/t/xhtml01.t
+++ b/t/xhtml01.t
@@ -1,7 +1,7 @@
 # t/xhtml01.t - check basic output from Pod::Simple::XHTML
 use strict;
 use warnings;
-use Test::More tests => 64;
+use Test::More tests => 65;
 
 use_ok('Pod::Simple::XHTML') or exit;
 
@@ -621,6 +621,18 @@ is($results, <<"EOHTML", "File name in a paragraph");
 <p>A plain paragraph with a <i>filename</i>.</p>
 
 EOHTML
+
+initialize($parser, $results);
+$parser->parse_string_document(<<'EOPOD');
+=pod
+
+A plain paragraph with U<underlined text>.
+EOPOD
+is($results, <<"EOHTML", "Underlined text in a paragraph");
+<p>A plain paragraph with <u>underlined text</u>.</p>
+
+EOHTML
+
 
 # It's not important that 's (apostrophes) be encoded for XHTML output.
 initialize($parser, $results);


### PR DESCRIPTION
Adds support for a `U<>` formatting code for underlined text, and support in all of the relevant formatters.

This is an implementation of the proposed spec change Perl/perl5#21509