### PR TITLE
corpus.t, htmlbat.t: don't write to `t` directory during testing

### DIFF
--- a/t/corpus.t
+++ b/t/corpus.t
@@ -25,9 +25,9 @@ BEGIN {
   my $corpusdir = File::Spec->catdir(File::Basename::dirname(Cwd::abs_path(__FILE__)), 'corpus');
   diag "Corpusdir: $corpusdir";
 
-  opendir(INDIR, $corpusdir) or die "Can't opendir corpusdir : $!";
-  my @f = map File::Spec::->catfile($corpusdir, $_), readdir(INDIR);
-  closedir(INDIR);
+  opendir(my $indir, $corpusdir) or die "Can't opendir $corpusdir : $!";
+  my @f = map File::Spec::->catfile($corpusdir, $_), readdir($indir);
+  closedir($indir);
   my %f;
   @f{@f} = ();
   foreach my $maybetest (sort @f) {
@@ -92,10 +92,10 @@ foreach my $f (@testfiles) {
 
   my $outfilename = ($HACK > 1) ? $wouldxml{$f} : "$wouldxml{$f}\_out";
   if($HACK) {
-    open OUT, ">$outfilename" or die "Can't write-open $outfilename: $!\n";
-    binmode(OUT);
-    print OUT $outstring;
-    close(OUT);
+    open my $out, ">", $outfilename or die "Can't write-open $outfilename: $!\n";
+    binmode($out);
+    print $out $outstring;
+    close($out);
   }
   unless($xml) {
     diag " (no comparison done)";
@@ -103,11 +103,11 @@ foreach my $f (@testfiles) {
     next;
   }
 
-  open(IN, "<$xml") or die "Can't read-open $xml: $!";
+  open(my $in, "<", $xml) or die "Can't read-open $xml: $!";
   #binmode(IN);
   local $/;
-  my $xmlsource = <IN>;
-  close(IN);
+  my $xmlsource = <$in>;
+  close($in);
 
   diag "There's errata!" if $outstring =~ m/start_line="-321"/;
 

--- a/t/corpus.t
+++ b/t/corpus.t
@@ -48,7 +48,10 @@ BEGIN {
   plan tests => (2*@testfiles - 1);
 }
 
-my $HACK = 1;
+my $HACK = 0;
+# 1: write generated XML dump to *.xml_out files for debugging
+# 2: write generated XML to *.xml files, updating/overwriting test corpus
+
 #@testfiles = ('nonesuch.txt');
 
 {
@@ -115,13 +118,13 @@ foreach my $f (@testfiles) {
   $outstring =~ s/[\n\r]+/\n/g;
   if($xmlsource eq $outstring) {
     diag " (Perfect match to $xml)";
-    unlink $outfilename unless $outfilename =~ m/\.xml$/is;
+    unlink $outfilename if $HACK == 1;
     ok 1;
     next;
   }
 
   diag " $outfilename and $xml don't match!";
-  print STDERR `diff $xml $outfilename`;
+  print STDERR `diff $xml $outfilename` if $HACK;
   ok 0;
 
 }

--- a/t/htmlbat.t
+++ b/t/htmlbat.t
@@ -4,9 +4,9 @@ use warnings;
 
 use Test::More tests => 13;
 
-#sub Pod::Simple::HTMLBatch::DEBUG () {5};
+#sub Pod::Simple::HTMLBatch::DEBUG () {5}
 
-require Pod::Simple::HTMLBatch;;
+require Pod::Simple::HTMLBatch;
 
 use File::Spec;
 use Cwd;
@@ -24,9 +24,9 @@ note "OK, found the test corpus as $corpus_dir";
 
 my $outdir;
 while(1) {
-  my $rand = sprintf "%05x", rand( 0x100000 );
-  $outdir = File::Spec->catdir( $t_dir, "delme-$rand-out" );
-  last unless -e $outdir;
+    my $rand = sprintf "%05x", rand( 0x100000 );
+    $outdir = File::Spec->catdir( $t_dir, "delme-$rand-out" );
+    last unless -e $outdir;
 }
 
 END {
@@ -48,25 +48,24 @@ note "OK, back from converting";
 my @files;
 use File::Find;
 find( sub {
-      push @files, $File::Find::name;
-      if (/[.]html\z/ && !/perl|index/) {
-          # Make sure an index was generated.
-          open my $fh, '<', $_ or die "Cannot open $_: $!\n";
-          my $html = do { local $/; <$fh> };
-          close $fh;
-          like $html, qr/<div class='indexgroup'>/;
-      }
-      return;
+    push @files, $File::Find::name;
+    if (/[.]html\z/ && !/perl|index/) {
+        # Make sure an index was generated.
+        open my $fh, '<', $_ or die "Cannot open $_: $!\n";
+        my $html = do { local $/; <$fh> };
+        close $fh;
+        like $html, qr/<div class='indexgroup'>/;
+    }
 }, $outdir );
 
 {
-  my $long = ( grep m/zikzik\./i, @files )[0];
-  ok($long) or diag "How odd, no zikzik file in $outdir!?";
-  if($long) {
-    $long =~ s{zikzik\.html?\z}{};
-    for(@files) { substr($_, 0, length($long)) = '' }
-    @files = grep length($_), @files;
-  }
+    my $long = ( grep m/zikzik\./i, @files )[0];
+    ok($long) or diag "How odd, no zikzik file in $outdir!?";
+    if($long) {
+        $long =~ s{zikzik\.html?\z}{};
+        for(@files) { substr($_, 0, length($long)) = ''; }
+        @files = grep length($_), @files;
+    }
 }
 
 note "Produced in $outdir ...";

--- a/t/htmlbat.t
+++ b/t/htmlbat.t
@@ -80,7 +80,7 @@ cmp_ok scalar(grep m/\.css\z/i, @files), '>', 5;
 cmp_ok scalar(grep m/\.html?\z/i, @files), '>', 5;
 cmp_ok scalar(grep m{squaa\W+Glunk.html?\z}i, @files), '>', 0;
 
-if (my @long = grep { /^[^.]{9,}/ } map { s{^[^/]/}{} } @files) {
+if (my @long = grep { /^[^.]{9,}/ } map { File::Basename::basename($_) } @files) {
     ok 0;
     diag "   File names too long:";
     diag "        $_" for @long;

--- a/t/htmlbat.t
+++ b/t/htmlbat.t
@@ -77,7 +77,7 @@ note "(", scalar(@files), " items total)";
 # Some minimal sanity checks:
 cmp_ok scalar(grep m/\.css\z/i, @files), '>', 5;
 cmp_ok scalar(grep m/\.html?\z/i, @files), '>', 5;
-cmp_ok scalar(grep m{squaa\W+Glunk.html?\z}i, @files), '>', 0;
+cmp_ok scalar(grep m{squaa\W+Glunk\.html?\z}i, @files), '>', 0;
 
 my @long = grep { /^[^.]{9,}/ } map { File::Basename::basename($_) } @files;
 unless (is scalar(@long), 0, "Generated filenames fit in 8.* format") {

--- a/t/htmlbat.t
+++ b/t/htmlbat.t
@@ -8,19 +8,12 @@ use Test::More tests => 13;
 
 require Pod::Simple::HTMLBatch;
 
-use File::Spec;
-use Cwd;
-my $cwd = cwd();
-note "CWD: $cwd";
-
-use File::Spec;
+use File::Spec ();
 use Cwd ();
 use File::Basename ();
 
 my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
 my $corpus_dir = File::Spec->catdir($t_dir, 'testlib1');
-
-note "OK, found the test corpus as $corpus_dir";
 
 my $outdir;
 while(1) {

--- a/t/htmlbat.t
+++ b/t/htmlbat.t
@@ -49,7 +49,7 @@ my @files;
 use File::Find;
 find( sub {
       push @files, $File::Find::name;
-      if (/[.]html$/ && $_ !~ /perl|index/) {
+      if (/[.]html\z/ && $_ !~ /perl|index/) {
           # Make sure an index was generated.
           open HTML, $_ or die "Cannot open $_: $!\n";
           my $html = do { local $/; <HTML> };
@@ -63,7 +63,7 @@ find( sub {
   my $long = ( grep m/zikzik\./i, @files )[0];
   ok($long) or diag "How odd, no zikzik file in $outdir!?";
   if($long) {
-    $long =~ s{zikzik\.html?$}{}s;
+    $long =~ s{zikzik\.html?\z}{};
     for(@files) { substr($_, 0, length($long)) = '' }
     @files = grep length($_), @files;
   }
@@ -76,9 +76,9 @@ foreach my $f (sort @files) {
 note "(", scalar(@files), " items total)";
 
 # Some minimal sanity checks:
-ok scalar(grep m/\.css/i, @files) > 5;
-ok scalar(grep m/\.html?/i, @files) > 5;
-ok scalar grep m{squaa\W+Glunk.html?}i, @files;
+cmp_ok scalar(grep m/\.css\z/i, @files), '>', 5;
+cmp_ok scalar(grep m/\.html?\z/i, @files), '>', 5;
+cmp_ok scalar(grep m{squaa\W+Glunk.html?\z}i, @files), '>', 0;
 
 if (my @long = grep { /^[^.]{9,}/ } map { s{^[^/]/}{} } @files) {
     ok 0;

--- a/t/htmlbat.t
+++ b/t/htmlbat.t
@@ -80,12 +80,10 @@ cmp_ok scalar(grep m/\.css\z/i, @files), '>', 5;
 cmp_ok scalar(grep m/\.html?\z/i, @files), '>', 5;
 cmp_ok scalar(grep m{squaa\W+Glunk.html?\z}i, @files), '>', 0;
 
-if (my @long = grep { /^[^.]{9,}/ } map { File::Basename::basename($_) } @files) {
-    ok 0;
+my @long = grep { /^[^.]{9,}/ } map { File::Basename::basename($_) } @files;
+unless (is scalar(@long), 0, "Generated filenames fit in 8.* format") {
     diag "   File names too long:";
     diag "        $_" for @long;
-} else {
-    ok 1;
 }
 
 # use Pod::Simple;

--- a/t/htmlbat.t
+++ b/t/htmlbat.t
@@ -13,7 +13,7 @@ require Pod::Simple::HTMLBatch;;
 use File::Spec;
 use Cwd;
 my $cwd = cwd();
-print "# CWD: $cwd\n" if $DEBUG;
+diag "CWD: $cwd" if $DEBUG;
 
 use File::Spec;
 use Cwd ();
@@ -22,7 +22,7 @@ use File::Basename ();
 my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
 my $corpus_dir = File::Spec->catdir($t_dir, 'testlib1');
 
-print "# OK, found the test corpus as $corpus_dir\n" if $DEBUG;
+diag "OK, found the test corpus as $corpus_dir" if $DEBUG;
 
 my $outdir;
 while(1) {
@@ -37,17 +37,17 @@ END {
 }
 
 ok 1;
-print "# Output dir: $outdir\n" if $DEBUG;
+diag "Output dir: $outdir" if $DEBUG;
 
 mkdir $outdir, 0777 or die "Can't mkdir $outdir: $!";
 
-print "# Converting $corpus_dir => $outdir\n" if $DEBUG;
+diag "Converting $corpus_dir => $outdir" if $DEBUG;
 my $conv = Pod::Simple::HTMLBatch->new;
 $conv->verbose(0);
 $conv->index(1);
 $conv->batch_convert( [$corpus_dir], $outdir );
 ok 1;
-print "# OK, back from converting.\n" if $DEBUG;
+diag "OK, back from converting." if $DEBUG;
 
 my @files;
 use File::Find;
@@ -65,7 +65,7 @@ find( sub {
 
 {
   my $long = ( grep m/zikzik\./i, @files )[0];
-  ok($long) or print "# How odd, no zikzik file in $outdir!?\n";
+  ok($long) or diag "How odd, no zikzik file in $outdir!?";
   if($long) {
     $long =~ s{zikzik\.html?$}{}s;
     for(@files) { substr($_, 0, length($long)) = '' }
@@ -74,11 +74,11 @@ find( sub {
 }
 
 if ($DEBUG) {
-    print "#Produced in $outdir ...\n";
+    diag "Produced in $outdir ...";
     foreach my $f (sort @files) {
-        print "#   $f\n";
+        diag "  $f";
     }
-    print "# (", scalar(@files), " items total)\n";
+    diag "(", scalar(@files), " items total)";
 }
 
 # Some minimal sanity checks:
@@ -88,8 +88,8 @@ ok scalar grep m{squaa\W+Glunk.html?}i, @files;
 
 if (my @long = grep { /^[^.]{9,}/ } map { s{^[^/]/}{} } @files) {
     ok 0;
-    print "#    File names too long:\n",
-        map { "#         $_\n" } @long;
+    diag "   File names too long:";
+    diag "        $_" for @long;
 } else {
     ok 1;
 }

--- a/t/htmlbat.t
+++ b/t/htmlbat.t
@@ -49,11 +49,11 @@ my @files;
 use File::Find;
 find( sub {
       push @files, $File::Find::name;
-      if (/[.]html\z/ && $_ !~ /perl|index/) {
+      if (/[.]html\z/ && !/perl|index/) {
           # Make sure an index was generated.
-          open HTML, $_ or die "Cannot open $_: $!\n";
-          my $html = do { local $/; <HTML> };
-          close HTML;
+          open my $fh, '<', $_ or die "Cannot open $_: $!\n";
+          my $html = do { local $/; <$fh> };
+          close $fh;
           like $html, qr/<div class='indexgroup'>/;
       }
       return;

--- a/t/htmlbat.t
+++ b/t/htmlbat.t
@@ -85,6 +85,3 @@ unless (is scalar(@long), 0, "Generated filenames fit in 8.* format") {
     diag "   File names too long:";
     diag "        $_" for @long;
 }
-
-# use Pod::Simple;
-# *pretty = \&Pod::Simple::BlackBox::pretty;

--- a/t/htmlbat.t
+++ b/t/htmlbat.t
@@ -15,10 +15,11 @@ use File::Basename ();
 my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
 my $corpus_dir = File::Spec->catdir($t_dir, 'testlib1');
 
+my $temp_dir = File::Spec->tmpdir;
 my $outdir;
 while(1) {
     my $rand = sprintf "%05x", rand( 0x100000 );
-    $outdir = File::Spec->catdir( $t_dir, "delme-$rand-out" );
+    $outdir = File::Spec->catdir( $temp_dir, "delme-$rand-out" );
     last unless -e $outdir;
 }
 

--- a/t/htmlbat.t
+++ b/t/htmlbat.t
@@ -2,18 +2,16 @@
 use strict;
 use warnings;
 
-use Test::More tests => 15;
+use Test::More tests => 13;
 
 #sub Pod::Simple::HTMLBatch::DEBUG () {5};
-
-my $DEBUG = 0;
 
 require Pod::Simple::HTMLBatch;;
 
 use File::Spec;
 use Cwd;
 my $cwd = cwd();
-diag "CWD: $cwd" if $DEBUG;
+note "CWD: $cwd";
 
 use File::Spec;
 use Cwd ();
@@ -22,7 +20,7 @@ use File::Basename ();
 my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
 my $corpus_dir = File::Spec->catdir($t_dir, 'testlib1');
 
-diag "OK, found the test corpus as $corpus_dir" if $DEBUG;
+note "OK, found the test corpus as $corpus_dir";
 
 my $outdir;
 while(1) {
@@ -36,18 +34,16 @@ END {
     rmtree $outdir, 0, 0;
 }
 
-ok 1;
-diag "Output dir: $outdir" if $DEBUG;
+note "Output dir: $outdir";
 
 mkdir $outdir, 0777 or die "Can't mkdir $outdir: $!";
 
-diag "Converting $corpus_dir => $outdir" if $DEBUG;
+note "Converting $corpus_dir => $outdir";
 my $conv = Pod::Simple::HTMLBatch->new;
 $conv->verbose(0);
 $conv->index(1);
 $conv->batch_convert( [$corpus_dir], $outdir );
-ok 1;
-diag "OK, back from converting." if $DEBUG;
+note "OK, back from converting";
 
 my @files;
 use File::Find;
@@ -73,13 +69,11 @@ find( sub {
   }
 }
 
-if ($DEBUG) {
-    diag "Produced in $outdir ...";
-    foreach my $f (sort @files) {
-        diag "  $f";
-    }
-    diag "(", scalar(@files), " items total)";
+note "Produced in $outdir ...";
+foreach my $f (sort @files) {
+    note "  $f";
 }
+note "(", scalar(@files), " items total)";
 
 # Some minimal sanity checks:
 ok scalar(grep m/\.css/i, @files) > 5;


### PR DESCRIPTION
Some tests cause problems if run with a read-only `t` directory (see also https://github.com/Perl/perl5/issues/22352).

Also, lots of little clean-ups:
- remove duplicate `use` statements
- remove or fix broken code that has never worked before (`$skippy`, filename length checks)
- remove bareword filehandles
- ...