### PR TITLE
Silence noise from corpus test

### DIFF
--- a/t/corpus.t
+++ b/t/corpus.t
@@ -80,14 +80,12 @@ foreach my $f (@testfiles) {
     undef $p;
   };
 
-  if($@) {
-    diag "** Couldn't parse $f:\n $@";
-    ok 0;
+  is $@, '', "parsed $f without error" or do {
     ok 0;
     next;
-  }
+  };
 
-  ok 1, "OK, parsing $f generated " . length($outstring) . " bytes";
+  note "generated " . length($outstring) . " bytes";
 
   die "Null outstring?" unless $outstring;
 
@@ -116,15 +114,9 @@ foreach my $f (@testfiles) {
 
   $xmlsource =~ s/[\n\r]+/\n/g;
   $outstring =~ s/[\n\r]+/\n/g;
-  if($xmlsource eq $outstring) {
-    note " (Perfect match to $xml)";
-    unlink $outfilename if $HACK == 1;
-    ok 1;
-    next;
-  }
+  ok $xmlsource eq $outstring, "perfect match to $xml" or do {
+    diag `diff $xml $outfilename` if $HACK;
+  };
 
-  diag " $outfilename and $xml don't match!";
-  print STDERR `diff $xml $outfilename` if $HACK;
-  ok 0;
-
+  unlink $outfilename if $HACK == 1;
 }

--- a/t/corpus.t
+++ b/t/corpus.t
@@ -23,7 +23,7 @@ my(@testfiles, %xmlfiles, %wouldxml);
 #use Pod::Simple::Debug (10);
 BEGIN {
   my $corpusdir = File::Spec->catdir(File::Basename::dirname(Cwd::abs_path(__FILE__)), 'corpus');
-  diag "Corpusdir: $corpusdir";
+  note "Corpusdir: $corpusdir";
 
   opendir(my $indir, $corpusdir) or die "Can't opendir $corpusdir : $!";
   my @f = map File::Spec::->catfile($corpusdir, $_), readdir($indir);
@@ -56,8 +56,8 @@ my $HACK = 0;
 
 {
   my @x = @testfiles;
-  diag "Files to test:";
-  while(@x) { diag " ", join(' ', splice @x,0,3); }
+  note "Files to test:";
+  while(@x) { note " ", join(' ', splice @x,0,3); }
 }
 
 require Pod::Simple::DumpAsXML;
@@ -65,11 +65,11 @@ require Pod::Simple::DumpAsXML;
 
 foreach my $f (@testfiles) {
   my $xml = $xmlfiles{$f};
-  diag "";
+  note "";
   if($xml) {
-    diag "To test $f against $xml";
+    note "To test $f against $xml";
   } else {
-    diag "$f has no xml to test it against";
+    note "$f has no xml to test it against";
   }
 
   my $outstring;
@@ -101,7 +101,7 @@ foreach my $f (@testfiles) {
     close($out);
   }
   unless($xml) {
-    diag " (no comparison done)";
+    note " (no comparison done)";
     ok 1;
     next;
   }
@@ -112,12 +112,12 @@ foreach my $f (@testfiles) {
   my $xmlsource = <$in>;
   close($in);
 
-  diag "There's errata!" if $outstring =~ m/start_line="-321"/;
+  note "There's errata!" if $outstring =~ m/start_line="-321"/;
 
   $xmlsource =~ s/[\n\r]+/\n/g;
   $outstring =~ s/[\n\r]+/\n/g;
   if($xmlsource eq $outstring) {
-    diag " (Perfect match to $xml)";
+    note " (Perfect match to $xml)";
     unlink $outfilename if $HACK == 1;
     ok 1;
     next;


### PR DESCRIPTION
After #162, the `corpus.t` test outputs a lot of noise, because it is using `diag` for extra information for its passing cases.

Convert those uses of `diag` to use `note` instead, and change some cases to named tests.