### PR TITLE
Point manpages to `man7.org` (supporting HTTPS and anchors)

### DIFF
--- a/lib/Pod/Simple/HTML.pm
+++ b/lib/Pod/Simple/HTML.pm
@@ -35,8 +35,8 @@ $Perldoc_URL_Postfix = ''
  unless defined $Perldoc_URL_Postfix;
 
 
-our $Man_URL_Prefix  = 'http://man.he.net/man';
-our $Man_URL_Postfix = '';
+our $Man_URL_Prefix  = 'https://man7.org/linux/man-pages/man';
+our $Man_URL_Postfix = '.html';
 
 our $Title_Prefix;
 $Title_Prefix  = '' unless defined $Title_Prefix;
@@ -59,7 +59,7 @@ __PACKAGE__->_accessorize(
    # In turning L<crontab(5)> into http://whatever/man/1/crontab, what
    #  to put before the "1/crontab".
  'man_url_postfix',
-   #  what to put after the "1/crontab" in the URL. Normally "".
+   #  what to put after the "1/crontab" in the URL. Normally ".html".
 
  'batch_mode', # whether we're in batch mode
  'batch_mode_current_level',
@@ -797,7 +797,7 @@ sub resolve_man_page_link {
   $section ||= 1;
 
   return $self->man_url_prefix . "$section/"
-      . $self->manpage_url_escape($page)
+      . $self->manpage_url_escape($page) . ".$section"
       . $self->man_url_postfix;
 }
 
@@ -1135,11 +1135,6 @@ under the same terms as Perl itself.
 This program is distributed in the hope that it will be useful, but
 without any warranty; without even the implied warranty of
 merchantability or fitness for a particular purpose.
-
-=head1 ACKNOWLEDGEMENTS
-
-Thanks to L<Hurricane Electric|http://he.net/> for permission to use its
-L<Linux man pages online|http://man.he.net/> site for man page links.
 
 =head1 AUTHOR
 

--- a/lib/Pod/Simple/XHTML.pm
+++ b/lib/Pod/Simple/XHTML.pm
@@ -129,13 +129,14 @@ default.
 
 =head2 man_url_prefix
 
-In turning C<< L<crontab(5)> >> into http://whatever/man/1/crontab, what
-to put before the "1/crontab". The default value is
-"http://man.he.net/man".
+In turning C<< L<crontab(5)> >> into http://whatever/man/1/crontab.1, what
+to put before the "1/crontab.1". The default value is
+"https://man7.org/linux/man-pages/man".
 
 =head2 man_url_postfix
 
-What to put after "1/crontab" in the URL. This option is not set by default.
+What to put after "1/crontab.1" in the URL.
+This option is set to ".html" by default.
 
 =head2 title_prefix, title_postfix
 
@@ -276,7 +277,8 @@ sub new {
   my $new = $self->SUPER::new(@_);
   $new->{'output_fh'} ||= *STDOUT{IO};
   $new->perldoc_url_prefix('https://metacpan.org/pod/');
-  $new->man_url_prefix('http://man.he.net/man');
+  $new->man_url_prefix('https://man7.org/linux/man-pages/man');
+  $new->man_url_postfix('.html');
   $new->html_charset('ISO-8859-1');
   $new->nix_X_codes(1);
   $new->{'scratch'} = '';
@@ -774,25 +776,25 @@ sub resolve_pod_page_link {
 Resolves a man page link target and numeric section to a URL. The resulting
 link will be returned for the above examples as:
 
-    http://man.he.net/man5/crontab
-    http://man.he.net/man1/crontab
+    https://man7.org/linux/man-pages/man5/crontab.5.html
+    https://man7.org/linux/man-pages/man1/crontab.1.html
 
 Note that the first argument is required. The section number will be parsed
 from it, and if it's missing will default to 1. The second argument is
-currently ignored, as L<man.he.net|http://man.he.net> does not currently
-include linkable IDs or anchor names in its pages. Subclass to link to a
-different man page HTTP server.
+currently ignored. Subclass to link to a different man page HTTP server.
 
 =cut
 
 sub resolve_man_page_link {
     my ($self, $to, $section) = @_;
     return undef unless defined $to;
+
     my ($page, $part) = $to =~ /^([^(]+)(?:[(](\d+)[)])?$/;
     return undef unless $page;
+
     return ($self->man_url_prefix || '')
         . ($part || 1) . "/" . $self->encode_entities($page)
-        . ($self->man_url_postfix || '');
+        . "." . ($part || 1) . ($self->man_url_postfix || '');
 
 }
 
@@ -904,11 +906,6 @@ under the same terms as Perl itself.
 This program is distributed in the hope that it will be useful, but
 without any warranty; without even the implied warranty of
 merchantability or fitness for a particular purpose.
-
-=head1 ACKNOWLEDGEMENTS
-
-Thanks to L<Hurricane Electric|http://he.net/> for permission to use its
-L<Linux man pages online|http://man.he.net/> site for man page links.
 
 =head1 AUTHOR
 

--- a/t/fcodes_s.t
+++ b/t/fcodes_s.t
@@ -215,7 +215,8 @@ is(
 # Test HTML output of links.
 use Pod::Simple::HTML;
 my $PERLDOC = "https://metacpan.org/pod";
-my $MANURL = "http://man.he.net/man";
+my $MANURL = "https://man7.org/linux/man-pages/man";
+my $MANURL_POSTFIX = ".html";
 sub x {
     Pod::Simple::HTML->_out(
         sub {  $_[0]->bare_output(1)  },
@@ -240,7 +241,7 @@ is(
 
 is(
     x(qq{L<crontab(5)>\n}),
-    qq{\n<p><a href="${MANURL}5/crontab" class="podlinkman"\n>crontab(5)</a></p>\n}
+    qq{\n<p><a href="${MANURL}5/crontab.5${MANURL_POSTFIX}" class="podlinkman"\n>crontab(5)</a></p>\n}
 );
 
 is(
@@ -300,12 +301,12 @@ is(
 
 is(
     x(qq{L<things|crontab(5)>\n}),
-    qq{\n<p><a href="${MANURL}5/crontab" class="podlinkman"\n>things</a></p>\n}
+    qq{\n<p><a href="${MANURL}5/crontab.5${MANURL_POSTFIX}" class="podlinkman"\n>things</a></p>\n}
 );
 
 is(
     x(qq{L<things|crontab(5)/ENVIRONMENT>\n}),
-    qq{\n<p><a href="${MANURL}5/crontab" class="podlinkman"\n>things</a></p>\n}
+    qq{\n<p><a href="${MANURL}5/crontab.5${MANURL_POSTFIX}" class="podlinkman"\n>things</a></p>\n}
 );
 
 is(
@@ -362,7 +363,7 @@ is(
 
 is(
     o(qq{L<crontab(5)>}),
-    qq{<p><a href="${MANURL}5/crontab">crontab(5)</a></p>\n\n}
+    qq{<p><a href="${MANURL}5/crontab.5${MANURL_POSTFIX}">crontab(5)</a></p>\n\n}
 );
 
 is(
@@ -422,12 +423,12 @@ is(
 
 is(
     o(qq{L<things|crontab(5)>}),
-    qq{<p><a href="${MANURL}5/crontab">things</a></p>\n\n}
+    qq{<p><a href="${MANURL}5/crontab.5${MANURL_POSTFIX}">things</a></p>\n\n}
 );
 
 is(
     o(qq{L<things|crontab(5)/ENVIRONMENT>}),
-    qq{<p><a href="${MANURL}5/crontab">things</a></p>\n\n}
+    qq{<p><a href="${MANURL}5/crontab.5${MANURL_POSTFIX}">things</a></p>\n\n}
 );
 
 is(

--- a/t/xhtml01.t
+++ b/t/xhtml01.t
@@ -11,7 +11,8 @@ isa_ok ($parser, 'Pod::Simple::XHTML');
 my $results;
 
 my $PERLDOC = "https://metacpan.org/pod";
-my $MANURL = "http://man.he.net/man";
+my $MANURL = "https://man7.org/linux/man-pages/man";
+my $MANURL_POSTFIX = ".html";
 
 initialize($parser, $results);
 $parser->parse_string_document( "=head1 Poit!" );
@@ -788,11 +789,11 @@ is $parser->resolve_pod_page_link('perlpod', 'this that'),
     'POD link with fragment with space';
 
 is $parser->resolve_man_page_link('crontab(5)', 'EXAMPLE CRON FILE'),
-    "${MANURL}5/crontab", 'Man link with fragment';
+    "${MANURL}5/crontab.5${MANURL_POSTFIX}", 'Man link with fragment';
 is $parser->resolve_man_page_link('crontab(5)'),
-    "${MANURL}5/crontab", 'Man link without fragment';
+    "${MANURL}5/crontab.5${MANURL_POSTFIX}", 'Man link without fragment';
 is $parser->resolve_man_page_link('crontab'),
-    "${MANURL}1/crontab", 'Man link without section';
+    "${MANURL}1/crontab.1${MANURL_POSTFIX}", 'Man link without section';
 
 # Make sure that batch_mode_page_object_init() works.
 ok $parser->batch_mode_page_object_init(0, 0, 0, 0, 6),


### PR DESCRIPTION
Instead of HTTP-only man.he.net

Avoiding "Not secure" warnings thereby

Fixes #150

#### Symbols
- `resolve_man_page_link` method
- `$Man_URL_Prefix`: `man_url_prefix()` (accessorized)
- `$Man_URL_Postfix`: `man_url_postfix()` (accessorized)