### PR TITLE
When Pod-Simple is in PERL_CORE we can build with a readonly source directory

### DIFF
--- a/t/JustPod_corpus.t
+++ b/t/JustPod_corpus.t
@@ -20,7 +20,7 @@ use Pod::Simple::JustPod;
 my @test_files;
 
 BEGIN {
-  my $test_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+  my $test_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
   print "# TESTDIR: $test_dir\n";
 

--- a/t/corpus.t
+++ b/t/corpus.t
@@ -16,13 +16,12 @@ BEGIN {
 #use Pod::Simple::Debug (10);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
 my(@testfiles, %xmlfiles, %wouldxml);
 #use Pod::Simple::Debug (10);
 BEGIN {
-  my $corpusdir = File::Spec->catdir(File::Basename::dirname(Cwd::abs_path(__FILE__)), 'corpus');
+  my $corpusdir = File::Spec->catdir(File::Basename::dirname(File::Spec->rel2abs(__FILE__)), 'corpus');
   note "Corpusdir: $corpusdir";
 
   opendir(my $indir, $corpusdir) or die "Can't opendir $corpusdir : $!";

--- a/t/encod01.t
+++ b/t/encod01.t
@@ -13,11 +13,10 @@ use Pod::Simple::DumpAsXML;
 my $thefile;
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
 BEGIN {
-  my $corpusdir = File::Spec->catdir(File::Basename::dirname(Cwd::abs_path(__FILE__)), 'corpus');
+  my $corpusdir = File::Spec->catdir(File::Basename::dirname(File::Spec->rel2abs(__FILE__)), 'corpus');
   $thefile = File::Spec->catfile($corpusdir, 'nonesuch.txt');
 }
 

--- a/t/htmlbat.t
+++ b/t/htmlbat.t
@@ -9,10 +9,9 @@ use Test::More tests => 13;
 require Pod::Simple::HTMLBatch;
 
 use File::Spec ();
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 my $corpus_dir = File::Spec->catdir($t_dir, 'testlib1');
 
 my $temp_dir = File::Spec->tmpdir;

--- a/t/output.t
+++ b/t/output.t
@@ -5,10 +5,9 @@ use warnings;
 use Test::More tests => 36;
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 for my $format (qw(XHTML HTML Text RTF)) {
     my $class = "Pod::Simple::$format";

--- a/t/reinit.t
+++ b/t/reinit.t
@@ -3,7 +3,6 @@ use warnings;
 use Test::More tests => 5;
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
 use Pod::Simple::Text;
@@ -18,7 +17,7 @@ foreach my $file (
   "perlfaq.pod",
   "perlvar.pod",
 ) {
-    my $full_file = File::Spec->catfile(File::Basename::dirname(Cwd::abs_path(__FILE__)), $file);
+    my $full_file = File::Spec->catfile(File::Basename::dirname(File::Spec->rel2abs(__FILE__)), $file);
 
     unless(-e $full_file) {
         ok 0;

--- a/t/render.t
+++ b/t/render.t
@@ -14,7 +14,6 @@ $Pod::Simple::Text::FREAKYMODE = 1;
 use Pod::Simple::TiedOutFH ();
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
 my $outfile = '10000';
@@ -26,7 +25,7 @@ foreach my $file (
   "perlfaq.pod",
   "perlvar.pod",
 ) {
-  my $full_file = File::Spec->catfile(File::Basename::dirname(Cwd::abs_path(__FILE__)), $file);
+  my $full_file = File::Spec->catfile(File::Basename::dirname(File::Spec->rel2abs(__FILE__)), $file);
 
   unless(-e $full_file) {
     ok 0;

--- a/t/rtf_utf8.t
+++ b/t/rtf_utf8.t
@@ -11,10 +11,9 @@ else {
 }
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $expected = join "", <DATA>;
 

--- a/t/search10.t
+++ b/t/search10.t
@@ -15,10 +15,9 @@ die "Couldn't make an object!?" unless ok defined $x;
 $x->inc(0);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here = File::Spec->catdir($t_dir, 'testlib1');
 

--- a/t/search12.t
+++ b/t/search12.t
@@ -13,10 +13,9 @@ die "Couldn't make an object!?" unless ok defined $x;
 $x->inc(0);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here = File::Spec->catdir($t_dir, 'testlib1');
 

--- a/t/search20.t
+++ b/t/search20.t
@@ -17,10 +17,9 @@ $x->callback(sub {
 });
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here1 = File::Spec->catdir($t_dir, 'testlib1');
 my $here2 = File::Spec->catdir($t_dir, 'testlib2');

--- a/t/search22.t
+++ b/t/search22.t
@@ -14,10 +14,9 @@ $x->inc(0);
 $x->shadows(1);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here1 = File::Spec->catdir($t_dir, 'testlib1');
 my $here2 = File::Spec->catdir($t_dir, 'testlib2');

--- a/t/search25.t
+++ b/t/search25.t
@@ -16,10 +16,9 @@ $x->inc(0);
 $x->shadows(1);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here1 = File::Spec->catdir($t_dir, 'testlib1');
 my $here2 = File::Spec->catdir($t_dir, 'testlib2');

--- a/t/search26.t
+++ b/t/search26.t
@@ -18,10 +18,9 @@ $x->inc(0);
 $x->shadows(1);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here1 = File::Spec->catdir($t_dir, 'testlib1');
 my $here2 = File::Spec->catdir($t_dir, 'testlib2');

--- a/t/search27.t
+++ b/t/search27.t
@@ -13,10 +13,9 @@ $x->inc(0);
 $x->shadows(1);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here1 = File::Spec->catdir($t_dir, 'testlib1');
 my $here2 = File::Spec->catdir($t_dir, 'testlib2');

--- a/t/search28.t
+++ b/t/search28.t
@@ -13,10 +13,9 @@ $x->inc(0);
 $x->shadows(1);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here1 = File::Spec->catdir($t_dir, 'testlib1');
 my $here2 = File::Spec->catdir($t_dir, 'testlib2');

--- a/t/search29.t
+++ b/t/search29.t
@@ -13,10 +13,9 @@ $x->inc(0);
 $x->shadows(1);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $here1 = File::Spec->catdir($t_dir, 'testlib1');
 my $here2 = File::Spec->catdir($t_dir, 'testlib2');

--- a/t/search60.t
+++ b/t/search60.t
@@ -13,10 +13,9 @@ $x->inc(0);
 $x->is_case_insensitive(0);
 
 use File::Spec;
-use Cwd ();
 use File::Basename ();
 
-my $t_dir = File::Basename::dirname(Cwd::abs_path(__FILE__));
+my $t_dir = File::Basename::dirname(File::Spec->rel2abs(__FILE__));
 
 my $A = File::Spec->catdir($t_dir, 'search60', 'A');
 my $B = File::Spec->catdir($t_dir, 'search60', 'B');


### PR DESCRIPTION
Because Cwd::abs_path resolves symlinks, it means if we are in PERL_CORE and building perl outside of the source directory, whle the main source directory is readonly, some of the tests fail because they can't write to the source directory when they should be writing to the build directory, or ideally to a tmpdir.

https://github.com/Perl/perl5/blob/blead/INSTALL#building-perl-outside-of-the-source-directory

We use this feature in OpenBSD.