### PR TITLE
fix string comparisons with $] to use numeric comparison instead

### DIFF
--- a/lib/Pod/Simple.pm
+++ b/lib/Pod/Simple.pm
@@ -33,8 +33,8 @@ BEGIN {
     die "MANY_LINES is too small (", MANY_LINES(), ")!\nAborting";
   }
   if(defined &UNICODE) { }
-  elsif($] >= 5.008)   { *UNICODE = sub() {1}  }
-  else                 { *UNICODE = sub() {''} }
+  elsif( do { no integer; "$]" >= 5.008 } ) { *UNICODE = sub() {1}  }
+  else                                      { *UNICODE = sub() {''} }
 }
 if(DEBUG > 2) {
   print STDERR "# We are ", ASCII ? '' : 'not ', "in ASCII-land\n";
@@ -42,8 +42,8 @@ if(DEBUG > 2) {
 }
 
 # The NO BREAK SPACE and SOFT HYHPEN are used in several submodules.
-if ($] ge 5.007_003) {  # On sufficiently modern Perls we can handle any
-                        # character set
+if ( do { no integer; "$]" >= 5.007_003 } ) {  # On sufficiently modern Perls we can handle any
+                          # character set
   $Pod::Simple::nbsp = chr utf8::unicode_to_native(0xA0);
   $Pod::Simple::shy  = chr utf8::unicode_to_native(0xAD);
 }

--- a/lib/Pod/Simple/BlackBox.pm
+++ b/lib/Pod/Simple/BlackBox.pm
@@ -35,7 +35,7 @@ sub my_qr ($$) {
     my ($input_re, $should_match) = @_;
     # XXX could have a third parameter $shouldnt_match for extra safety
 
-    my $use_utf8 = ($] le 5.006002) ? 'use utf8;' : "";
+    my $use_utf8 = do { no integer; $] <= 5.006002 } ? 'use utf8;' : "";
 
     my $re = eval "no warnings; $use_utf8 qr/$input_re/";
     #print STDERR  __LINE__, ": $input_re: $@\n" if $@;
@@ -93,7 +93,7 @@ my $deprecated_re = my_qr('\p{IsDeprecated}', "\x{149}");
 $deprecated_re = qr/\x{149}/ unless $deprecated_re;
 
 my $utf8_bom;
-if (($] ge 5.007_003)) {
+if ( do { no integer; "$]" >= 5.007_003 }) {
   $utf8_bom = "\x{FEFF}";
   utf8::encode($utf8_bom);
 } else {
@@ -266,13 +266,13 @@ sub parse_lines {             # Usage: $parser->parse_lines(@lines)
       # XXX probably if the line has E<foo> that evaluates to illegal CP1252,
       # then it is UTF-8.  But we haven't processed E<> yet.
 
-      goto set_1252 if $] lt 5.006_000;    # No UTF-8 on very early perls
+      goto set_1252 if do { no integer; "$]" < 5.006_000 };    # No UTF-8 on very early perls
 
       my $copy;
 
       no warnings 'utf8';
 
-      if ($] ge 5.007_003) {
+      if ( do { no integer; "$]" >= 5.007_003 } ) {
         $copy = $line;
 
         # On perls that have this function, we can use it to easily see if the
@@ -286,7 +286,7 @@ sub parse_lines {             # Usage: $parser->parse_lines(@lines)
       }
       else { # ASCII, no decode(): do it ourselves using the fundamental
              # characteristics of UTF-8
-        use if $] le 5.006002, 'utf8';
+        use if do { no integer; "$]" <= 5.006002 }, 'utf8';
 
         my $char_ord;
         my $needed;         # How many continuation bytes to gobble up

--- a/lib/Pod/Simple/DumpAsXML.pm
+++ b/lib/Pod/Simple/DumpAsXML.pm
@@ -67,7 +67,7 @@ sub _handle_element_end {
 sub _xml_escape {
   foreach my $x (@_) {
     # Escape things very cautiously:
-    if ($] ge 5.007_003) {
+    if ("$]" >= 5.007_003) {
       $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(utf8::native_to_unicode(ord($1))).';'/eg;
     } else { # Is broken for non-ASCII platforms on early perls
       $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(ord($1)).';'/eg;

--- a/lib/Pod/Simple/HTML.pm
+++ b/lib/Pod/Simple/HTML.pm
@@ -702,7 +702,7 @@ sub section_name_tidy {
   $section =~ s/^\s+//;
   $section =~ s/\s+$//;
   $section =~ tr/ /_/;
-  if ($] ge 5.006) {
+  if ("$]" >= 5.006) {
     $section =~ s/[[:cntrl:][:^ascii:]]//g; # drop crazy characters
   } elsif ('A' eq chr(65)) { # But not on early EBCDIC
     $section =~ tr/\x00-\x1F\x80-\x9F//d;
@@ -725,7 +725,7 @@ sub general_url_escape {
   # A pretty conservative escaping, behoovey even for query components
   #  of a URL (see RFC 2396)
 
-  if ($] ge 5.007_003) {
+  if ("$]" >= 5.007_003) {
     $string =~ s/([^-_\.!~*()abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/sprintf('%%%02X',utf8::native_to_unicode(ord($1)))/eg;
   } else { # Is broken for non-ASCII platforms on early perls
     $string =~ s/([^-_\.!~*()abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/sprintf('%%%02X',ord($1))/eg;
@@ -863,7 +863,7 @@ sub esc { # a function.
       @_ = splice @_; # break aliasing
     } else {
       my $x = shift;
-      if ($] ge 5.007_003) {
+      if ("$]" >= 5.007_003) {
         $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(utf8::native_to_unicode(ord($1))).';'/eg;
       } else { # Is broken for non-ASCII platforms on early perls
         $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(ord($1)).';'/eg;
@@ -874,7 +874,7 @@ sub esc { # a function.
   foreach my $x (@_) {
     # Escape things very cautiously:
     if (defined $x) {
-      if ($] ge 5.007_003) {
+      if ("$]" >= 5.007_003) {
         $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(utf8::native_to_unicode(ord($1))).';'/eg
       } else { # Is broken for non-ASCII platforms on early perls
         $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(ord($1)).';'/eg

--- a/lib/Pod/Simple/RTF.pm
+++ b/lib/Pod/Simple/RTF.pm
@@ -18,7 +18,7 @@ sub to_uni ($) {    # Convert native code point to Unicode
     my $x = shift;
 
     # Broken for early EBCDICs
-    $x = chr utf8::native_to_unicode(ord $x) if $] ge 5.007_003
+    $x = chr utf8::native_to_unicode(ord $x) if "$]" >= 5.007_003
                                              && ord("A") != 65;
     return $x;
 }
@@ -551,7 +551,7 @@ my $other_unicode =
         Pod::Simple::BlackBox::my_qr('([\x{10000}-\x{10FFFF}])', "\x{10000}");
 
 sub esc_uni($) {
-    use if $] le 5.006002, 'utf8';
+    use if do { no integer; "$]" <= 5.006002 }, 'utf8';
 
     my $x = shift;
 

--- a/lib/Pod/Simple/XMLOutStream.pm
+++ b/lib/Pod/Simple/XMLOutStream.pm
@@ -76,7 +76,7 @@ sub _handle_element_end {
 sub _xml_escape {
   foreach my $x (@_) {
     # Escape things very cautiously:
-    if ($] ge 5.007_003) {
+    if ("$]" >= 5.007_003) {
       $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(utf8::native_to_unicode(ord($1))).';'/eg;
     } else { # Is broken for non-ASCII platforms on early perls
       $x =~ s/([^-\n\t !\#\$\%\(\)\*\+,\.\~\/\:\;=\?\@\[\\\]\^_\`\{\|\}abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789])/'&#'.(ord($1)).';'/eg;

--- a/t/ascii_order.pl
+++ b/t/ascii_order.pl
@@ -5,7 +5,7 @@ sub native_to_uni($) {  # Convert from platform character set to Unicode
     my $string = shift;
 
     return $string if ord("A") == 65
-                      || $] lt 5.007_003; # Doesn't work on early EBCDIC Perls
+                      || "$]" < 5.007_003; # Doesn't work on early EBCDIC Perls
     my $output = "";
     for my $i (0 .. length($string) - 1) {
         $output .= chr(utf8::native_to_unicode(ord(substr($string, $i, 1))));

--- a/t/encod04.t
+++ b/t/encod04.t
@@ -18,7 +18,7 @@ use Pod::Simple::XMLOutStream;
 my $x97;
 my $x91;
 my $dash;
-if ($] ge 5.007_003) {
+if ("$]" >= 5.007_003) {
     $x97 = chr utf8::unicode_to_native(0x97);
     $x91 = chr utf8::unicode_to_native(0x91);
     $dash = '&#8212';


### PR DESCRIPTION
The fix follows Zefram's suggestion from
https://www.nntp.perl.org/group/perl.perl5.porters/2012/05/msg186846.html

> On older perls, however, $] had a numeric value that was built up using
> floating-point arithmetic, such as 5+0.006+0.000002.  This would not
> necessarily match the conversion of the complete value from string form
> [perl #72210].  You can work around that by explicitly stringifying
> $] (which produces a correct string) and having *that* numify (to a
> correctly-converted floating point value) for comparison.  I cultivate
> the habit of always stringifying $] to work around this, regardless of
> the threshold where the bug was fixed.  So I'd write
>
>     use if "$]" >= 5.014, warnings => "non_unicode";

Note that, because some of the files do a `use integer`, the numeric
comparisons with $] a `no integer` needs to be done in a lexical scope
around the comparison, to avoid truncation to integers, which spoils
the comparisons. Hence the ugly `do { no integer ; ... }` in some places.