### PR TITLE
Include MANIFEST and SKIP in GH repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 _build
 blib
 Pod-Simple-*
-MANIFEST
 MANIFEST.bak
 *META.*
 Build


### PR DESCRIPTION
Git should be aware of MANIFEST and MANIFEST.SKIP.  Once your code is on github.com, someone may fork it and want to run it through the typical 'perl Makefile.PL -- make -- make test' cycle.  Save them the trouble of calling 'make manifest' unless they've modified either of those files.