### PR TITLE
Pod::Simple::XHTML: better fallback when HTML::Entities isn't installed

### DIFF
--- a/lib/Pod/Simple/XHTML.pm
+++ b/lib/Pod/Simple/XHTML.pm
@@ -70,10 +70,11 @@ sub encode_entities {
       $ents =~ s,(?<!\\)([]/]),\\$1,g;
       $ents =~ s,(?<!\\)\\\z,\\\\,;
   } else {
-      $ents = join '', keys %entities;
+      # the same set of characters as in HTML::Entities
+      $ents = '^\n\r\t !\#\$%\(-;=?-~';
   }
   my $str = $_[0];
-  $str =~ s/([$ents])/'&' . ($entities{$1} || sprintf '#x%X', ord $1) . ';'/ge;
+  $str =~ s/([$ents])/'&' . ($entities{$1} || sprintf '#x%X', unpack('U', $1)) . ';'/ge;
   return $str;
 }
 

--- a/t/xhtml01.t
+++ b/t/xhtml01.t
@@ -1,7 +1,7 @@
 # t/xhtml01.t - check basic output from Pod::Simple::XHTML
 use strict;
 use warnings;
-use Test::More tests => 66;
+use Test::More tests => 68;
 
 use_ok('Pod::Simple::XHTML') or exit;
 
@@ -712,7 +712,7 @@ is($results, "$html\n\n", "Text with =begin html");
 
 SKIP: for my $use_html_entities (0, 1) {
   if ($use_html_entities and not $Pod::Simple::XHTML::HAS_HTML_ENTITIES) {
-    skip("HTML::Entities not installed", 3);
+    skip("HTML::Entities not installed", 4);
   }
   local $Pod::Simple::XHTML::HAS_HTML_ENTITIES = $use_html_entities;
   initialize($parser, $results);
@@ -751,11 +751,28 @@ EOHTML
   # Keep =encoding out of content.
   initialize($parser, $results);
   $parser->parse_string_document("=encoding ascii\n\n=head1 NAME\n");
-  is($results, <<"EOHTML", 'Encoding should not be in content')
+  is($results, <<"EOHTML", 'Encoding should not be in content');
 <h1 id="NAME">NAME</h1>
 
 EOHTML
 
+  initialize($parser, $results);
+  $parser->parse_string_document(<<"EOPOD");
+=pod
+
+=encoding UTF-8
+
+The pilcrow, ¶, is used to mark the beginning of a new paragraph.
+
+=cut
+
+EOPOD
+
+  $T = $use_html_entities ? '&para;' : '&#xB6;';
+  is($results, <<"EOHTML", 'Non-ASCII characters are escaped')
+<p>The pilcrow, ${T}, is used to mark the beginning of a new paragraph.</p>
+
+EOHTML
 }
 
 


### PR DESCRIPTION
This commit changes the default set of escaped characters in the fallback code to be the same as in HTML::Entities.

Fixes #188