### PR TITLE
fix encoding of unicode URL fragments

### DIFF
--- a/lib/Pod/Simple/XHTML.pm
+++ b/lib/Pod/Simple/XHTML.pm
@@ -95,12 +95,17 @@ sub decode_entities {
   return $string;
 }
 
+sub HAVE_UTF8_ENCODE ();
+BEGIN {
+  *HAVE_UTF8_ENCODE = defined &utf8::encode ? sub () { 1 } : sub () { 0 };
+}
+my %percent_enc = map +( chr($_) => sprintf('%%%02X', $_) ), 0 .. 255;
+
 sub encode_url {
   my ($self, $string) = @_;
 
-  $string =~ s{([^-_.!~*()abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZZ0123456789])}{
-    sprintf('%%%02X', ord($1))
-  }eg;
+  utf8::encode($string) if HAVE_UTF8_ENCODE;
+  $string =~ s{([^-_.!~*()a-zA-Z0-9])}{$percent_enc{$1}}g;
 
   return $string;
 }

--- a/t/xhtml25.t
+++ b/t/xhtml25.t
@@ -39,6 +39,7 @@ BEGIN {
     }
 }
 
+local $Pod::Simple::XHTML::HAS_HTML_ENTITIES = 0;
 
 my @tests = (
     # Pod                   id                        link (url encoded)
@@ -55,35 +56,44 @@ my $parser = MyXHTML->new;
 for my $names (@tests) {
     my ($heading, $id, $link) = @$names;
 
-    is $link, $parser->encode_url($id),
-        'assert correct encoding of url fragment';
+    my $heading_name = "for '$heading'";
+
+    is $parser->encode_url($id), $link,
+        "assert correct encoding of url fragment $heading_name";
 
     my $html_id = $parser->encode_entities($id);
 
     {
-        my $result = MyXHTML->new->parse_to_string(<<"EOT");
-=head1 $heading
+        my $pod = <<"EOT";
+    =head1 $heading
 
-L<< /$heading >>
+    L<< /$heading >>
 
 EOT
+        $pod =~ s/^    //gm;
+
+        my $result = MyXHTML->new->parse_to_string("$pod");
+
         like $result, qr{<h1 id="\Q$html_id\E">},
-            "heading id generated correctly for '$heading'";
+            "heading id generated correctly $heading_name";
         like $result, qr{<li><a href="\#\Q$link\E">},
-            "index link generated correctly for '$heading'";
+            "index link generated correctly $heading_name";
         like $result, qr{<p><a href="\#\Q$link\E">},
-            "L<> link generated correctly for '$heading'";
+            "L<> link generated correctly $heading_name";
     }
     {
-        my $result = MyXHTML->new->parse_to_string(<<"EOT");
-=over 4
+        my $pod = <<"EOT";
+    =over 4
 
-=item $heading
+    =item $heading
 
-=back
+    =back
 
 EOT
+        $pod =~ s/^    //gm;
+
+        my $result = MyXHTML->new->parse_to_string("$pod");
         like $result, qr{<dt id="\Q$html_id\E">},
-            "item id generated correctly for '$heading'";
+            "item id generated correctly for $heading_name";
     }
 }

--- a/t/xhtml25.t
+++ b/t/xhtml25.t
@@ -47,6 +47,9 @@ my @tests = (
     [ '$@',                 '$@',                     '%24%40'                    ],
     [ 'With C<Formatting>', 'With-Formatting',        'With-Formatting'           ],
     [ '$obj->method($foo)', '$obj->method($foo)',     '%24obj-%3Emethod(%24foo)'  ],
+    [ 'bjørn',              'bjørn',                  'bj%C3%B8rn',  'ISO-8859-1' ],
+    [ 'bjørn',              'bjørn',                  'bj%C3%B8rn',       'UTF-8' ],
+    [ '🌐',                 '🌐',                     '%F0%9F%8C%90',     'UTF-8' ],
 );
 
 plan tests => 5 * scalar @tests;
@@ -54,9 +57,30 @@ plan tests => 5 * scalar @tests;
 my $parser = MyXHTML->new;
 
 for my $names (@tests) {
-    my ($heading, $id, $link) = @$names;
+    my ($heading, $id, $link, $encoding) = @$names;
 
-    my $heading_name = "for '$heading'";
+    my $heading_name = "for '$heading'" . ($encoding ? " ($encoding)" : '');
+
+    my $encoding_dir = '';
+    if ($encoding) {
+        if (!Pod::Simple::XHTML::HAVE_UTF8_ENCODE) {
+            skip 'no encoding support', 5;
+        }
+        elsif ($encoding eq 'ISO-8859-1') {
+            utf8::decode($heading);
+            utf8::downgrade($heading);
+        }
+        elsif ($encoding eq 'UTF-8') {
+            # source is already UTF-8 encoded
+        }
+        else {
+            die "this test only supports ISO-8859-1 and UTF-8";
+        }
+
+        utf8::decode($id);
+
+        $encoding_dir = "=encoding $encoding\n\n";
+    }
 
     is $parser->encode_url($id), $link,
         "assert correct encoding of url fragment $heading_name";
@@ -72,7 +96,7 @@ for my $names (@tests) {
 EOT
         $pod =~ s/^    //gm;
 
-        my $result = MyXHTML->new->parse_to_string("$pod");
+        my $result = MyXHTML->new->parse_to_string("$encoding_dir$pod");
 
         like $result, qr{<h1 id="\Q$html_id\E">},
             "heading id generated correctly $heading_name";
@@ -92,7 +116,7 @@ EOT
 EOT
         $pod =~ s/^    //gm;
 
-        my $result = MyXHTML->new->parse_to_string("$pod");
+        my $result = MyXHTML->new->parse_to_string("$encoding_dir$pod");
         like $result, qr{<dt id="\Q$html_id\E">},
             "item id generated correctly for $heading_name";
     }


### PR DESCRIPTION
URL fragments are percent encoded. Percent encoding is a byte encoding, so its input must be encoded as UTF-8. Even for documents using a different encoding in their source, such as ISO-8859-1, browsers expect the URL fragments to be UTF-8 encoded.

Since percent encodings only ever deal with 0 to 255, we can precalculate a mapping of characters to encoded form. Encode the URL as UTF-8, then use the mapping to percent encode the result.

No fallback is provided if utf8::encode is not available. If you try to use this with non-ascii characters on perl 5.6, you get to keep both pieces.